### PR TITLE
Improve MkDocs theme color scheme detection and pin material version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           python-version: '3.12'
 
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material==9.7.2
 
       - run: mkdocs gh-deploy --force

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,13 +8,15 @@ edit_uri: edit/main/docs/
 theme:
   name: material
   palette:
-    - scheme: default
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
       primary: indigo
       accent: indigo
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
-    - scheme: slate
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
       primary: indigo
       accent: indigo
       toggle:


### PR DESCRIPTION
## Description

This PR makes two improvements to the documentation build configuration:

1. **Enhanced color scheme detection**: Updated the MkDocs Material theme palette configuration to use CSS media queries (`prefers-color-scheme`) for automatic light/dark mode detection. This allows the documentation to respect the user's system-level color scheme preference instead of requiring manual toggling.

2. **Pinned mkdocs-material version**: Locked `mkdocs-material` to version 9.7.2 in the GitHub Actions workflow to ensure consistent builds and prevent unexpected breaking changes from future releases.

## Checklist
- [x] Documentation configuration changes reviewed
- [x] GitHub Actions workflow updated appropriately
- [x] No code changes requiring unit tests

https://claude.ai/code/session_01Mfe8rHL4NmHybh5btZf5hu