### PR TITLE
Support OutlinedTextField and improve testTag detection

### DIFF
--- a/dejavu/src/main/java/dejavu/internal/DejavuTracer.kt
+++ b/dejavu/src/main/java/dejavu/internal/DejavuTracer.kt
@@ -183,7 +183,7 @@ internal object DejavuTracer : CompositionTracer {
         "TopAppBarLayout",
         "Spacer", "LazyVerticalGrid", "LazyHorizontalGrid",
         "AnimatedVisibility", "AnimatedContent", "Crossfade",
-        "Dialog", "Popup", "TextField", "BasicTextField",
+        "Dialog", "Popup", "TextField", "BasicTextField", "OutlinedTextField",
         "HorizontalPager", "VerticalPager",
     )
 
@@ -304,12 +304,14 @@ internal object DejavuTracer : CompositionTracer {
                 var foundTag = false
 
                 // Approach 0: InspectableValue API (Compose 1.3+ ModifierNodeElement)
+                // Handles both older Compose (value = tag → element name "") and
+                // newer Compose (properties["tag"] = tag → element name "tag").
                 try {
                     val modifier = mi.modifier
                     if (modifier is InspectableValue) {
                         if (modifier.nameFallback == "testTag") {
                             for (element in modifier.inspectableElements) {
-                                if (element.name == "tag" && element.value is String) {
+                                if (element.value is String) {
                                     val tag = element.value as String
                                     testTagToFunction.putIfAbsent(tag, currentUserComposable)
                                     lastSeenTags.add(tag)
@@ -434,7 +436,7 @@ internal object DejavuTracer : CompositionTracer {
                     val modifier = mi.modifier
                     if (modifier is InspectableValue && modifier.nameFallback == "testTag") {
                         for (element in modifier.inspectableElements) {
-                            if (element.name == "tag" && element.value is String) {
+                            if (element.value is String) {
                                 unmappedTags.add(element.value as String)
                             }
                         }
@@ -496,7 +498,7 @@ internal object DejavuTracer : CompositionTracer {
                     val modifier = mi.modifier
                     if (modifier is InspectableValue && modifier.nameFallback == "testTag") {
                         for (element in modifier.inspectableElements) {
-                            if (element.name == "tag" && element.value is String) {
+                            if (element.value is String) {
                                 val tag = element.value as String
                                 if (tag in unmappedTags) {
                                     testTagToFunction.putIfAbsent(tag, currentUserComposable)


### PR DESCRIPTION
## Description

This PR makes two improvements to the DejavuTracer:

1. **Add OutlinedTextField to ignored composables**: Added "OutlinedTextField" to the list of composables that should be skipped during tracing, consistent with other text input components like "TextField" and "BasicTextField".

2. **Improve testTag element detection**: Relaxed the testTag element matching logic to handle both older and newer Compose versions. Previously, the code checked both `element.name == "tag"` and `element.value is String`. Now it only checks if `element.value is String`, which handles:
   - Older Compose versions where the element name might be empty
   - Newer Compose versions where the element name is "tag"
   
   This change was applied consistently across three locations in the tracer where testTag elements are extracted (lines 313, 439, and 501).

## Checklist
- [ ] JVM unit tests pass (`./gradlew :dejavu:testDebugUnitTest`)
- [ ] Lint passes (`./gradlew :dejavu:lintDebug`)
- [ ] API compatibility checked (`./gradlew apiCheck`)
- [ ] Instrumented tests pass (if applicable)
- [ ] New public API has KDoc

https://claude.ai/code/session_01P1CknGgEFirWUC7DR7Hp8m