### PR TITLE
Add framework composable test coverage

### DIFF
--- a/demo/src/androidTest/java/demo/app/AccuracyValidationTest.kt
+++ b/demo/src/androidTest/java/demo/app/AccuracyValidationTest.kt
@@ -659,3 +659,49 @@ class ScaffoldSlotsAccuracyTest {
         )
     }
 }
+
+// ============================================================
+// 16. FrameworkComposable (FrameworkComposableActivity)
+//
+// Regression test for PR #16: OutlinedTextField, TextField,
+// Switch, and Card wrapped in user composables must be
+// accurately tracked by Dejavu.
+// ============================================================
+
+@RunWith(AndroidJUnit4::class)
+class FrameworkComposableAccuracyTest {
+
+    @get:Rule
+    val rule = createRecompositionTrackingRule<FrameworkComposableActivity>()
+
+    @Before
+    fun setup() {
+        GroundTruthCounters.reset()
+    }
+
+    @Test
+    fun frameworkComposableAccuracy() {
+        rule.onNodeWithTag("type_char_trigger").performClick()
+        rule.waitForIdle()
+        rule.onNodeWithTag("toggle_trigger").performClick()
+        rule.waitForIdle()
+        rule.onNodeWithTag("increment_trigger").performClick()
+        rule.waitForIdle()
+
+        validateAccuracy(
+            rule,
+            listOf(
+                "fw_screen_root",
+                "task_description_input",
+                "simple_text_input",
+                "toggle_switch",
+                "info_card",
+                "counter_label",
+                "type_char_trigger",
+                "toggle_trigger",
+                "increment_trigger",
+            ),
+            "FrameworkComposable",
+        )
+    }
+}

--- a/demo/src/androidTest/java/demo/app/FrameworkComposableTest.kt
+++ b/demo/src/androidTest/java/demo/app/FrameworkComposableTest.kt
@@ -1,0 +1,84 @@
+package demo.app
+
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dejavu.assertRecompositions
+import dejavu.assertStable
+import dejavu.createRecompositionTrackingRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Validates that user composables wrapping Material3 framework composables
+ * (OutlinedTextField, TextField, Switch, Card) are properly tracked.
+ *
+ * Regression tests for PR #16: OutlinedTextField tag mapping failure.
+ */
+@RunWith(AndroidJUnit4::class)
+class FrameworkComposableTest {
+
+    @get:Rule
+    val composeTestRule = createRecompositionTrackingRule<FrameworkComposableActivity>()
+
+    @Test
+    fun outlinedTextField_typeCharacter_recomposesWrapper() {
+        composeTestRule.onNodeWithTag("type_char_trigger").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("task_description_input")
+            .assertRecompositions(atLeast = 1)
+    }
+
+    @Test
+    fun textField_typeCharacter_recomposesWrapper() {
+        composeTestRule.onNodeWithTag("type_char_trigger").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("simple_text_input")
+            .assertRecompositions(atLeast = 1)
+    }
+
+    @Test
+    fun switch_toggle_recomposesWrapper() {
+        composeTestRule.onNodeWithTag("toggle_trigger").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("toggle_switch")
+            .assertRecompositions(atLeast = 1)
+    }
+
+    @Test
+    fun card_counterIncrement_recomposesWrapper() {
+        composeTestRule.onNodeWithTag("increment_trigger").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("info_card")
+            .assertRecompositions(atLeast = 1)
+    }
+
+    @Test
+    fun unrelatedComposable_typeCharacter_remainsStable() {
+        composeTestRule.onNodeWithTag("type_char_trigger").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("counter_label").assertStable()
+    }
+
+    @Test
+    fun multipleInteractions_allTrackAccurately() {
+        composeTestRule.onNodeWithTag("type_char_trigger").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("toggle_trigger").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("increment_trigger").performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag("task_description_input")
+            .assertRecompositions(atLeast = 1)
+        composeTestRule.onNodeWithTag("simple_text_input")
+            .assertRecompositions(atLeast = 1)
+        composeTestRule.onNodeWithTag("toggle_switch")
+            .assertRecompositions(atLeast = 1)
+        composeTestRule.onNodeWithTag("info_card")
+            .assertRecompositions(atLeast = 1)
+        composeTestRule.onNodeWithTag("counter_label")
+            .assertRecompositions(atLeast = 1)
+    }
+}

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -102,5 +102,9 @@
         android:name=".ReorderListActivity"
         android:exported="false" />
 
+    <activity
+        android:name=".FrameworkComposableActivity"
+        android:exported="false" />
+
   </application>
 </manifest>

--- a/demo/src/main/java/demo/app/FrameworkComposableActivity.kt
+++ b/demo/src/main/java/demo/app/FrameworkComposableActivity.kt
@@ -1,0 +1,13 @@
+package demo.app
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import demo.app.ui.FrameworkComposableScreen
+
+class FrameworkComposableActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent { FrameworkComposableScreen() }
+    }
+}

--- a/demo/src/main/java/demo/app/ui/FrameworkComposable.kt
+++ b/demo/src/main/java/demo/app/ui/FrameworkComposable.kt
@@ -1,0 +1,118 @@
+package demo.app.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import demo.app.GroundTruthCounters
+
+@Composable
+fun FrameworkComposableScreen() {
+    SideEffect { GroundTruthCounters.increment("fw_screen_root") }
+    var outlinedText by remember { mutableStateOf("") }
+    var textFieldText by remember { mutableStateOf("") }
+    var switchState by remember { mutableStateOf(false) }
+    var counter by remember { mutableIntStateOf(0) }
+
+    Column(modifier = Modifier.testTag("fw_screen_root")) {
+        TaskDescriptionInput(
+            value = outlinedText,
+            onValueChanged = { outlinedText = it },
+        )
+        SimpleTextInput(
+            value = textFieldText,
+            onValueChanged = { textFieldText = it },
+        )
+        ToggleSwitch(checked = switchState, onCheckedChange = { switchState = it })
+        InfoCard(counter)
+        CounterLabel(counter)
+
+        TypeCharTrigger {
+            outlinedText += "a"
+            textFieldText += "b"
+        }
+        ToggleTrigger { switchState = !switchState }
+        IncrementTrigger { counter++ }
+    }
+}
+
+@Composable
+fun TaskDescriptionInput(value: String, onValueChanged: (String) -> Unit) {
+    SideEffect { GroundTruthCounters.increment("task_description_input") }
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChanged,
+        label = { Text("Description") },
+        modifier = Modifier.testTag("task_description_input"),
+    )
+}
+
+@Composable
+fun SimpleTextInput(value: String, onValueChanged: (String) -> Unit) {
+    SideEffect { GroundTruthCounters.increment("simple_text_input") }
+    TextField(
+        value = value,
+        onValueChange = onValueChanged,
+        modifier = Modifier.testTag("simple_text_input"),
+    )
+}
+
+@Composable
+fun ToggleSwitch(checked: Boolean, onCheckedChange: (Boolean) -> Unit) {
+    SideEffect { GroundTruthCounters.increment("toggle_switch") }
+    Switch(
+        checked = checked,
+        onCheckedChange = onCheckedChange,
+        modifier = Modifier.testTag("toggle_switch"),
+    )
+}
+
+@Composable
+fun InfoCard(counter: Int) {
+    SideEffect { GroundTruthCounters.increment("info_card") }
+    Card(modifier = Modifier.testTag("info_card")) {
+        Text("Card content: $counter")
+    }
+}
+
+@Composable
+fun CounterLabel(counter: Int) {
+    SideEffect { GroundTruthCounters.increment("counter_label") }
+    Text("Counter: $counter", modifier = Modifier.testTag("counter_label"))
+}
+
+@Composable
+private fun TypeCharTrigger(onClick: () -> Unit) {
+    SideEffect { GroundTruthCounters.increment("type_char_trigger") }
+    Button(onClick = onClick, modifier = Modifier.testTag("type_char_trigger")) {
+        Text("Type Char")
+    }
+}
+
+@Composable
+private fun ToggleTrigger(onClick: () -> Unit) {
+    SideEffect { GroundTruthCounters.increment("toggle_trigger") }
+    Button(onClick = onClick, modifier = Modifier.testTag("toggle_trigger")) {
+        Text("Toggle")
+    }
+}
+
+@Composable
+private fun IncrementTrigger(onClick: () -> Unit) {
+    SideEffect { GroundTruthCounters.increment("increment_trigger") }
+    Button(onClick = onClick, modifier = Modifier.testTag("increment_trigger")) {
+        Text("Increment")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds regression tests for PR #16 ensuring `OutlinedTextField`, `TextField`, `Switch`, and `Card` are properly tracked when wrapped in user composables
- Reproduces the exact pattern that failed in the TOA project (`TaskDescriptionInput` wrapping `OutlinedTextField` with a `testTag`)
- Adds ground-truth accuracy validation (SideEffect counters vs Dejavu counts)

## New files
- `FrameworkComposable.kt` — Screen with user composables wrapping Material3 framework composables
- `FrameworkComposableActivity.kt` — Activity host
- `FrameworkComposableTest.kt` — 6 instrumented regression tests
- `AccuracyValidationTest.kt` — Appended `FrameworkComposableAccuracyTest` (#16 in the accuracy series)

## Test plan
- [x] `connectedDebugAndroidTest` — all 7 new tests pass on Pixel 9 Pro Fold emulator (API 36)

🤖 Generated with [Claude Code](https://claude.com/claude-code)