### PR TITLE
Seed active activity from Android test rule

### DIFF
--- a/dejavu/src/androidMain/kotlin/dejavu/DejavuComposeTestRule.kt
+++ b/dejavu/src/androidMain/kotlin/dejavu/DejavuComposeTestRule.kt
@@ -25,6 +25,7 @@ public class DejavuComposeTestRule<A : ComponentActivity>(
         return delegate.apply(object : Statement() {
             override fun evaluate() {
                 Dejavu.enable(delegate.activity.application)
+                dejavu.internal.Runtime.setActiveActivity(delegate.activity)
                 delegate.waitForIdle()
                 DejavuTest.resetCounts()
                 base.evaluate()

--- a/dejavu/src/androidMain/kotlin/dejavu/DejavuComposeTestRule.kt
+++ b/dejavu/src/androidMain/kotlin/dejavu/DejavuComposeTestRule.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.rules.ActivityScenarioRule
+import dejavu.internal.Runtime
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
@@ -25,7 +26,7 @@ public class DejavuComposeTestRule<A : ComponentActivity>(
         return delegate.apply(object : Statement() {
             override fun evaluate() {
                 Dejavu.enable(delegate.activity.application)
-                dejavu.internal.Runtime.setActiveActivity(delegate.activity)
+                Runtime.seedActiveActivity(delegate.activity)
                 delegate.waitForIdle()
                 DejavuTest.resetCounts()
                 base.evaluate()

--- a/dejavu/src/androidMain/kotlin/dejavu/internal/Runtime.kt
+++ b/dejavu/src/androidMain/kotlin/dejavu/internal/Runtime.kt
@@ -335,6 +335,11 @@ internal object Runtime {
     return out
   }
 
+  internal fun setActiveActivity(activity: Activity) {
+    lastResumedRef = WeakReference(activity)
+    ensureInspectionTag(activity)
+  }
+
   private fun collectCompositionDataFromView(view: View): Set<Any> {
     val out: MutableSet<Any> = Collections.newSetFromMap(IdentityHashMap())
     // Read the inspection slot table set tag populated by Compose (on this view)

--- a/dejavu/src/androidMain/kotlin/dejavu/internal/Runtime.kt
+++ b/dejavu/src/androidMain/kotlin/dejavu/internal/Runtime.kt
@@ -42,7 +42,6 @@ internal object Runtime {
   private var lifecycleCallbacks: Application.ActivityLifecycleCallbacks? = null
   @Volatile
   private var lastResumedRef: WeakReference<Activity>? = null
-  private val knownActivities = mutableListOf<WeakReference<Activity>>()
 
   // Per-recomposer change count tracking
   private val recomposerChangeCount = IdentityHashMap<Any, Long>()
@@ -76,9 +75,6 @@ internal object Runtime {
     enabled = true
     this.logToLogcat = logToLogcat
     appRef = app
-    snapshotCandidateActivities().firstOrNull()?.let { activity ->
-      seedActiveActivity(activity)
-    }
 
     // Load the real observer delegate if Compose observer API is available
     observer = try {
@@ -154,12 +150,10 @@ internal object Runtime {
         activity: Activity,
         savedInstanceState: Bundle?
       ) {
-        rememberActivity(activity)
         ensureInspectionTag(activity)
       }
 
       override fun onActivityStarted(activity: Activity) {
-        rememberActivity(activity)
         ensureInspectionTag(activity)
       }
 
@@ -180,7 +174,9 @@ internal object Runtime {
       }
 
       override fun onActivityDestroyed(activity: Activity) {
-        forgetActivity(activity)
+        if (lastResumedRef?.get() === activity) {
+          lastResumedRef = null
+        }
       }
     }
     app.registerActivityLifecycleCallbacks(callbacks)
@@ -216,7 +212,6 @@ internal object Runtime {
       lifecycleCallbacks?.let { app.unregisterActivityLifecycleCallbacks(it) }
     }
     lifecycleCallbacks = null
-    lastResumedRef = null
     observedRecomposers.clear()
     recomposerChangeCount.clear()
     latestSnapshots.clear()
@@ -235,7 +230,6 @@ internal object Runtime {
 
   internal fun seedActiveActivity(activity: Activity) {
     if (!enabled) return
-    rememberActivity(activity)
     if (lastResumedRef?.get() === activity) return
     lastResumedRef = WeakReference(activity)
     ensureInspectionTag(activity)
@@ -344,56 +338,13 @@ internal object Runtime {
   }
 
   internal fun currentCompositionsSnapshot(): Set<CompositionData> {
+    val activity = lastResumedRef?.get() ?: return emptySet()
+    val root = activity.window?.decorView ?: return emptySet()
     val out: MutableSet<CompositionData> = Collections.newSetFromMap(IdentityHashMap())
-    for (activity in snapshotCandidateActivities()) {
-      ensureInspectionTag(activity)
-      val root = activity.window?.decorView ?: continue
-      collectCompositionDataFromView(root).forEach { any ->
-        if (any is CompositionData) out.add(any)
-      }
-      if (out.isNotEmpty()) {
-        if (lastResumedRef?.get() == null) {
-          lastResumedRef = WeakReference(activity)
-        }
-        return out
-      }
+    collectCompositionDataFromView(root).forEach { any ->
+      if (any is CompositionData) out.add(any)
     }
     return out
-  }
-
-  private fun rememberActivity(activity: Activity) {
-    synchronized(knownActivities) {
-      knownActivities.removeAll { ref ->
-        val existing = ref.get()
-        existing == null || existing === activity
-      }
-      knownActivities.add(WeakReference(activity))
-    }
-  }
-
-  private fun forgetActivity(activity: Activity) {
-    synchronized(knownActivities) {
-      knownActivities.removeAll { ref ->
-        val existing = ref.get()
-        existing == null || existing === activity
-      }
-    }
-    if (lastResumedRef?.get() === activity) {
-      lastResumedRef = null
-    }
-  }
-
-  private fun snapshotCandidateActivities(): List<Activity> {
-    val resumed = lastResumedRef?.get()
-    val snapshot = synchronized(knownActivities) {
-      knownActivities.mapNotNull { it.get() }
-    }
-    return buildList {
-      if (resumed != null) add(resumed)
-      snapshot.asReversed().forEach { activity ->
-        if (activity !== resumed) add(activity)
-      }
-    }
   }
 
   private fun collectCompositionDataFromView(view: View): Set<Any> {

--- a/dejavu/src/androidMain/kotlin/dejavu/internal/Runtime.kt
+++ b/dejavu/src/androidMain/kotlin/dejavu/internal/Runtime.kt
@@ -40,7 +40,9 @@ internal object Runtime {
   private var observer: ObserverDelegate = NoOpObserver
 
   private var lifecycleCallbacks: Application.ActivityLifecycleCallbacks? = null
+  @Volatile
   private var lastResumedRef: WeakReference<Activity>? = null
+  private val knownActivities = mutableListOf<WeakReference<Activity>>()
 
   // Per-recomposer change count tracking
   private val recomposerChangeCount = IdentityHashMap<Any, Long>()
@@ -74,6 +76,9 @@ internal object Runtime {
     enabled = true
     this.logToLogcat = logToLogcat
     appRef = app
+    snapshotCandidateActivities().firstOrNull()?.let { activity ->
+      seedActiveActivity(activity)
+    }
 
     // Load the real observer delegate if Compose observer API is available
     observer = try {
@@ -149,20 +154,17 @@ internal object Runtime {
         activity: Activity,
         savedInstanceState: Bundle?
       ) {
+        rememberActivity(activity)
         ensureInspectionTag(activity)
       }
 
       override fun onActivityStarted(activity: Activity) {
+        rememberActivity(activity)
         ensureInspectionTag(activity)
       }
 
       override fun onActivityResumed(activity: Activity) {
-        lastResumedRef = WeakReference(activity)
-        ensureInspectionTag(activity)
-        Choreographer.getInstance().postFrameCallback { _ ->
-          ensureInspectionTag(activity)
-        }
-        ensureFrameLoop()
+        seedActiveActivity(activity)
       }
 
       override fun onActivityPaused(activity: Activity) { /* no-op */
@@ -177,7 +179,8 @@ internal object Runtime {
       ) { /* no-op */
       }
 
-      override fun onActivityDestroyed(activity: Activity) { /* no-op */
+      override fun onActivityDestroyed(activity: Activity) {
+        forgetActivity(activity)
       }
     }
     app.registerActivityLifecycleCallbacks(callbacks)
@@ -228,6 +231,21 @@ internal object Runtime {
     val root = activity.window?.decorView ?: return
     val tagId = androidx.compose.ui.R.id.inspection_slot_table_set
     seedInspectionTagRecursively(root, tagId)
+  }
+
+  internal fun seedActiveActivity(activity: Activity) {
+    if (!enabled) return
+    rememberActivity(activity)
+    if (lastResumedRef?.get() === activity) return
+    lastResumedRef = WeakReference(activity)
+    ensureInspectionTag(activity)
+    Choreographer.getInstance().postFrameCallback { _ ->
+      if (!enabled) return@postFrameCallback
+      if (lastResumedRef?.get() === activity) {
+        ensureInspectionTag(activity)
+      }
+    }
+    ensureFrameLoop()
   }
 
   private fun seedInspectionTagRecursively(
@@ -326,18 +344,56 @@ internal object Runtime {
   }
 
   internal fun currentCompositionsSnapshot(): Set<CompositionData> {
-    val activity = lastResumedRef?.get() ?: return emptySet()
-    val root = activity.window?.decorView ?: return emptySet()
     val out: MutableSet<CompositionData> = Collections.newSetFromMap(IdentityHashMap())
-    collectCompositionDataFromView(root).forEach { any ->
-      if (any is CompositionData) out.add(any)
+    for (activity in snapshotCandidateActivities()) {
+      ensureInspectionTag(activity)
+      val root = activity.window?.decorView ?: continue
+      collectCompositionDataFromView(root).forEach { any ->
+        if (any is CompositionData) out.add(any)
+      }
+      if (out.isNotEmpty()) {
+        if (lastResumedRef?.get() == null) {
+          lastResumedRef = WeakReference(activity)
+        }
+        return out
+      }
     }
     return out
   }
 
-  internal fun setActiveActivity(activity: Activity) {
-    lastResumedRef = WeakReference(activity)
-    ensureInspectionTag(activity)
+  private fun rememberActivity(activity: Activity) {
+    synchronized(knownActivities) {
+      knownActivities.removeAll { ref ->
+        val existing = ref.get()
+        existing == null || existing === activity
+      }
+      knownActivities.add(WeakReference(activity))
+    }
+  }
+
+  private fun forgetActivity(activity: Activity) {
+    synchronized(knownActivities) {
+      knownActivities.removeAll { ref ->
+        val existing = ref.get()
+        existing == null || existing === activity
+      }
+    }
+    if (lastResumedRef?.get() === activity) {
+      lastResumedRef = null
+    }
+  }
+
+  private fun snapshotCandidateActivities(): List<Activity> {
+    val resumed = lastResumedRef?.get()
+    val snapshot = synchronized(knownActivities) {
+      knownActivities.mapNotNull { it.get() }
+    }
+    return buildList {
+      if (resumed != null) add(resumed)
+      snapshot.asReversed().forEach { activity ->
+        if (activity !== resumed) add(activity)
+      }
+    }
   }
 
   private fun collectCompositionDataFromView(view: View): Set<Any> {

--- a/demo/src/androidTest/java/demo/app/DejavuLibraryCorrectnessTest.kt
+++ b/demo/src/androidTest/java/demo/app/DejavuLibraryCorrectnessTest.kt
@@ -125,4 +125,19 @@ class DejavuLibraryCorrectnessTest {
         composeTestRule.onNodeWithTag("inc_button").performClick()
         composeTestRule.onNodeWithTag("counter_title").assertStable()
     }
+
+    @Test
+    fun reEnable_onAlreadyResumedActivity_restoresTrackedTagLookups() {
+        // Repro: enable() is called while the activity is already resumed, so
+        // onActivityResumed does not fire again to seed the active activity.
+        composeTestRule.runOnUiThread { Dejavu.disable() }
+        composeTestRule.runOnUiThread { Dejavu.enable(composeTestRule.activity.application) }
+        composeTestRule.waitForIdle()
+
+        // If the active activity is not reseeded, tag lookup for counter_value
+        // breaks here and the recomposition assertion fails.
+        composeTestRule.resetRecompositionCounts()
+        composeTestRule.onNodeWithTag("inc_button").performClick()
+        composeTestRule.onNodeWithTag("counter_value").assertRecompositions(exactly = 1)
+    }
 }


### PR DESCRIPTION
## Description
This is the smaller Android fix for the tag-mapping failure reported in `#51`.

On Android, Dejavu can be enabled after the test activity is already resumed. In that case, `currentCompositionsSnapshot()` can still see `lastResumedRef == null`, which leaves tag mapping without any composition snapshots and produces warnings like:

```text
Warning: testTag '...' could not be mapped to a composable function
```

This patch fixes that by explicitly seeding the current activity from DejavuComposeTestRule immediately after Dejavu.enable(...).

This is the smallest working fix, but it does push Android runtime recovery into the rule layer. I’m opening it as a simpler alternative to the cleaner runtime-only approach.

## Checklist

- [x] JVM unit tests pass (./gradlew :dejavu:testDebugUnitTest)
- [x] Lint passes (./gradlew :dejavu:lintDebug)
- [x] API compatibility checked (./gradlew apiCheck)
- [ ] Instrumented tests pass (if applicable)
- [ ] New public API has KDoc