### PR TITLE
⚡ Bolt: Fix unnecessary recompositions by converting CartSummary to data class

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-04-16 - Compose Recomposition and `data class`
+**Learning:** Compose uses identity-based equality (`Object.equals`) for regular classes, causing unnecessary recompositions when a new instance is passed, even if its fields are identical. Using a `data class` provides structural equality, allowing Compose to skip recomposition if the logical content hasn't changed.
+**Action:** Always prefer `data class` over `class` for data-holding parameters passed to Composables to prevent performance regressions via needless recompositions.

--- a/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
+++ b/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.unit.dp
 // ISSUE: Unstable class — uses identity-based equality (Object.equals),
 // causing recomposition even when the logical content is the same.
 // Making this a `data class` would fix the problem.
-class CartSummary(val itemCount: Int, val totalPrice: String)
+data class CartSummary(val itemCount: Int, val totalPrice: String)
 
 @Composable
 fun ProductListScreen() {

--- a/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
+++ b/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
@@ -116,7 +116,7 @@ class RecompositionRegressionTest {
         composeTestRule.onNodeWithTag("refresh_button").performClick()
 
         // ISSUE: CartBanner recomposes despite no logical change to the cart
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 1)
+        composeTestRule.onNodeWithTag("cart_banner").assertStable()
 
         // FIX: If CartSummary were a `data class`, equals() would compare
         // fields structurally. CartSummary(0, "$0.0") == CartSummary(0, "$0.0")
@@ -163,7 +163,7 @@ class RecompositionRegressionTest {
         // recomposition because CartSummary is unstable. That's 5 total
         // recompositions (2 from selects + 3 from refreshes).
         // Budget: at most 5 -- bounded at 1:1 with parent recompositions.
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atMost = 5)
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
 
         // FIX: With `data class CartSummary`, only the 2 select clicks
         // would cause recomposition (the content actually changes).
@@ -201,7 +201,7 @@ class RecompositionRegressionTest {
         // because each parent recomposition creates a new CartSummary instance.
         // FIX: With `data class CartSummary`, only the 2 selects would cause
         // recomposition. The fixed assertion would be: assertRecomposesExactly(2)
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 3)
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================


### PR DESCRIPTION
💡 What: Replaced `class CartSummary` with `data class CartSummary` in `demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt` and updated the corresponding recomposition tests.
🎯 Why: Regular classes rely on identity-based equality (`Object.equals`), resulting in a new instance always being seen as 'different' by Compose, which leads to needless recompositions of child UI elements like `CartBanner`. Converting it to a `data class` leverages structural equality.
📊 Impact: Eliminates unneeded recompositions of `CartBanner` on generic parent state changes (e.g. from 5 to 2 down in `performanceBudget_cartBannerOnMixedInteractions`), ensuring performance aligns directly with actual state variation.
🔬 Measurement: Verify via `demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt`, where the `cartBanner_recomposesOnUnrelatedRefresh` assertion has changed from at least 1 to `assertStable()`.

---
*PR created automatically by Jules for task [15279902665586926288](https://jules.google.com/task/15279902665586926288) started by @himattm*