### PR TITLE
⚡ Bolt: Use data class for CartSummary to avoid unnecessary recomposition

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-17 - Unstable Class Recomposition
+**Learning:** Standard classes used as Compose parameters without `@Stable` or structural equality (like `data class`) cause unnecessary recomposition because Compose relies on identity-based equality (`Object.equals`), triggering a recomposition even when the logical content is the same.
+**Action:** Always prefer `data class` for data holders passed to Composables so `equals()` is structural, preventing needless recomposition when parent recomposes for unrelated reasons.

--- a/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
+++ b/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.unit.dp
 // ISSUE: Unstable class — uses identity-based equality (Object.equals),
 // causing recomposition even when the logical content is the same.
 // Making this a `data class` would fix the problem.
-class CartSummary(val itemCount: Int, val totalPrice: String)
+data class CartSummary(val itemCount: Int, val totalPrice: String)
 
 @Composable
 fun ProductListScreen() {

--- a/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
+++ b/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
@@ -116,12 +116,12 @@ class RecompositionRegressionTest {
         composeTestRule.onNodeWithTag("refresh_button").performClick()
 
         // ISSUE: CartBanner recomposes despite no logical change to the cart
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 1)
+        composeTestRule.onNodeWithTag("cart_banner").assertStable()
 
         // FIX: If CartSummary were a `data class`, equals() would compare
         // fields structurally. CartSummary(0, "$0.0") == CartSummary(0, "$0.0")
         // would be true, and Compose would SKIP the recomposition.
-        // The fixed assertion would be: assertFirstComposition()
+        // The fixed assertion would be: assertStable()
     }
 
     // ============================================================
@@ -163,7 +163,7 @@ class RecompositionRegressionTest {
         // recomposition because CartSummary is unstable. That's 5 total
         // recompositions (2 from selects + 3 from refreshes).
         // Budget: at most 5 -- bounded at 1:1 with parent recompositions.
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atMost = 5)
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
 
         // FIX: With `data class CartSummary`, only the 2 select clicks
         // would cause recomposition (the content actually changes).
@@ -201,7 +201,7 @@ class RecompositionRegressionTest {
         // because each parent recomposition creates a new CartSummary instance.
         // FIX: With `data class CartSummary`, only the 2 selects would cause
         // recomposition. The fixed assertion would be: assertRecomposesExactly(2)
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 3)
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================


### PR DESCRIPTION
💡 **What**: Refactored the `CartSummary` class to be a `data class` to enable structural equality instead of identity-based equality.

🎯 **Why**: When a standard class is passed as a parameter in Jetpack Compose, Compose compares equality by reference. Therefore, if a parent component recomposed for an unrelated reason (like `refreshCount` changing), it created a new `CartSummary` instance. Because it was not a `data class`, Compose saw a new reference, assumed the parameter changed, and unnecessarily triggered recomposition of `CartBanner`, even if the actual item count and total price were identical.

📊 **Impact**: This significantly reduces unnecessary recompositions of `CartBanner`. Instead of recomposing on every unrelated parent recomposition, it only recomposes when the actual content (count or price) changes. This is reflected in the updated tests. For instance, the number of recompositions in `combinedInteractions_detectsAccumulatedIssues` drops from at least 3 to exactly 2.

🔬 **Measurement**: You can verify the performance impact by running the `demo` instrumentation tests, specifically `RecompositionRegressionTest`:
`./gradlew :demo:connectedDebugAndroidTest` or by observing the Dejavu recomposition counts in the test results.

---
*PR created automatically by Jules for task [2320885546068079489](https://jules.google.com/task/2320885546068079489) started by @himattm*