### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Unstable Class Parameter Causes Recomposition Regression
+**Learning:** Found a performance bottleneck where a regular class (not a data class) `CartSummary` was used as a parameter. It used identity-based equality (Object.equals) so when its parent composed for unrelated reasons, the child composable `CartBanner` would incorrectly recompose.
+**Action:** Changed `CartSummary` from a regular class to a `data class`. This ensures structural equality is used, allowing Compose to correctly skip recompositions when content is logically unchanged.

--- a/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
+++ b/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.unit.dp
 // ISSUE: Unstable class — uses identity-based equality (Object.equals),
 // causing recomposition even when the logical content is the same.
 // Making this a `data class` would fix the problem.
-class CartSummary(val itemCount: Int, val totalPrice: String)
+data class CartSummary(val itemCount: Int, val totalPrice: String)
 
 @Composable
 fun ProductListScreen() {

--- a/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
+++ b/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
@@ -116,7 +116,7 @@ class RecompositionRegressionTest {
         composeTestRule.onNodeWithTag("refresh_button").performClick()
 
         // ISSUE: CartBanner recomposes despite no logical change to the cart
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 1)
+        composeTestRule.onNodeWithTag("cart_banner").assertStable()
 
         // FIX: If CartSummary were a `data class`, equals() would compare
         // fields structurally. CartSummary(0, "$0.0") == CartSummary(0, "$0.0")
@@ -163,7 +163,7 @@ class RecompositionRegressionTest {
         // recomposition because CartSummary is unstable. That's 5 total
         // recompositions (2 from selects + 3 from refreshes).
         // Budget: at most 5 -- bounded at 1:1 with parent recompositions.
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atMost = 5)
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
 
         // FIX: With `data class CartSummary`, only the 2 select clicks
         // would cause recomposition (the content actually changes).
@@ -201,7 +201,7 @@ class RecompositionRegressionTest {
         // because each parent recomposition creates a new CartSummary instance.
         // FIX: With `data class CartSummary`, only the 2 selects would cause
         // recomposition. The fixed assertion would be: assertRecomposesExactly(2)
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 3)
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================


### PR DESCRIPTION
💡 What: Changed `class CartSummary` to `data class CartSummary` in `demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt` and updated the corresponding test assertions in `RecompositionRegressionTest.kt`.
🎯 Why: A regular class uses identity-based equality (Object.equals). Because of this, when the parent composed for unrelated reasons, a new `CartSummary` instance was created, and the child `CartBanner` composable was forced to recompose, leading to performance degradations. A `data class` leverages structural equality, enabling fine-grained invalidation.
📊 Impact: Reduced unnecessary `CartBanner` recompositions from 1:1 with the parent composable down to only actual changes. For instance, mixed operations now result in `cart_banner` correctly recomposing 2 times rather than 5 times.
🔬 Measurement: Verify this improvement with `./gradlew test` using the `RecompositionRegressionTest` assertions.

---
*PR created automatically by Jules for task [9765282200873350633](https://jules.google.com/task/9765282200873350633) started by @himattm*