### PR TITLE
⚡ Bolt: [performance improvement] Convert CartSummary to data class

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-21 - Compose data class equality
+**Learning:** Using regular classes instead of data classes for UI state in Jetpack Compose causes unnecessary recompositions because Compose uses reference equality by default.
+**Action:** Always use data classes for objects passed as parameters to Compose components to enable structural equality and allow Compose to skip recomposition when content hasn't changed.

--- a/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
+++ b/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
@@ -31,22 +31,9 @@ import androidx.compose.ui.unit.dp
 // Boolean, demonstrating the correct approach.
 // ============================================================
 
-// ============================================================
-// ISSUE 2 — Unstable class parameter (identity-based equality)
-// CartSummary is a regular class (NOT a data class). Its
-// equals() uses reference identity (Object.equals). When the
-// parent recomposes for ANY reason, a new CartSummary instance
-// is created. Even if the logical content (itemCount,
-// totalPrice) is identical, Compose sees a different reference
-// and recomposes CartBanner.
-//
-// FIX: Make CartSummary a data class so equals() is structural.
-// ============================================================
-
-// ISSUE: Unstable class — uses identity-based equality (Object.equals),
-// causing recomposition even when the logical content is the same.
-// Making this a `data class` would fix the problem.
-class CartSummary(val itemCount: Int, val totalPrice: String)
+// `CartSummary` is a `data class`, meaning equality is structural.
+// Compose skips recomposition when content is identical.
+data class CartSummary(val itemCount: Int, val totalPrice: String)
 
 @Composable
 fun ProductListScreen() {
@@ -64,17 +51,6 @@ fun ProductListScreen() {
             tag = "optimized_header",
         )
 
-        // ISSUE 2: New CartSummary instance created every recomposition of ProductListScreen.
-        // Because CartSummary is NOT a data class, each instance is != the previous
-        // even when itemCount and totalPrice hold the same values.
-        // This means CartBanner recomposes on EVERY parent recomposition --
-        // including refreshCount changes that don't affect the cart at all.
-        //
-        // KEY: refreshCount is read in ProductListScreen's scope (see
-        // RefreshIndicator below), so changing refreshCount recomposes this
-        // entire composable. That creates a new CartSummary with the SAME
-        // selectedCount, but because CartSummary uses identity equality,
-        // CartBanner sees a "different" parameter and recomposes needlessly.
         CartBanner(
             summary = CartSummary(
                 itemCount = selectedCount,
@@ -159,9 +135,6 @@ fun OptimizedProductHeader(hasSelection: Boolean, tag: String) {
     )
 }
 
-// ── ISSUE 2: Unstable class parameter ───────────────────────
-// CartSummary uses reference equality, so a new instance always
-// triggers recomposition — even if the values inside are identical.
 @Composable
 fun CartBanner(summary: CartSummary, tag: String) {
     SideEffect { GroundTruthCounters.increment(tag) }

--- a/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
+++ b/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
@@ -107,21 +107,15 @@ class RecompositionRegressionTest {
     // ============================================================
 
     @Test
-    fun cartBanner_recomposesOnUnrelatedRefresh() {
-        // CURRENT BEHAVIOR (issue): Clicking refresh changes refreshCount,
-        // which recomposes ProductListScreen. A new CartSummary(0, "$0.0")
-        // is created. Because CartSummary is NOT a data class, the new
-        // instance != the old instance (reference inequality), so
-        // CartBanner recomposes even though the cart content is unchanged.
+    fun cartBanner_staysStableOnUnrelatedRefresh() {
+        // Clicking refresh changes refreshCount, which recomposes
+        // ProductListScreen. A new CartSummary(0, "$0.0") is created.
+        // Because CartSummary is a data class, the new instance == the
+        // old instance (structural equality), so CartBanner skips
+        // recomposition because the cart content is unchanged.
         composeTestRule.onNodeWithTag("refresh_button").performClick()
 
-        // ISSUE: CartBanner recomposes despite no logical change to the cart
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 1)
-
-        // FIX: If CartSummary were a `data class`, equals() would compare
-        // fields structurally. CartSummary(0, "$0.0") == CartSummary(0, "$0.0")
-        // would be true, and Compose would SKIP the recomposition.
-        // The fixed assertion would be: assertFirstComposition()
+        composeTestRule.onNodeWithTag("cart_banner").assertStable()
     }
 
     // ============================================================
@@ -159,15 +153,10 @@ class RecompositionRegressionTest {
             composeTestRule.onNodeWithTag("refresh_button").performClick()
         }
 
-        // CURRENT BEHAVIOR (issue): CartBanner recomposes on EVERY parent
-        // recomposition because CartSummary is unstable. That's 5 total
-        // recompositions (2 from selects + 3 from refreshes).
-        // Budget: at most 5 -- bounded at 1:1 with parent recompositions.
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atMost = 5)
-
-        // FIX: With `data class CartSummary`, only the 2 select clicks
-        // would cause recomposition (the content actually changes).
-        // The fixed assertion would be: assertRecomposesExactly(2)
+        // With `data class CartSummary`, only the 2 select clicks
+        // cause recomposition (because the content actually changes).
+        // The 3 refreshes are skipped.
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================
@@ -197,11 +186,10 @@ class RecompositionRegressionTest {
         // Footer stays stable due to strong skipping mode memoizing the lambda
         composeTestRule.onNodeWithTag("product_footer").assertStable()
 
-        // ISSUE: CartBanner recomposes on ALL 3 interactions (2 selects + 1 refresh)
-        // because each parent recomposition creates a new CartSummary instance.
-        // FIX: With `data class CartSummary`, only the 2 selects would cause
-        // recomposition. The fixed assertion would be: assertRecomposesExactly(2)
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 3)
+        // With `data class CartSummary`, only the 2 selects cause
+        // recomposition. The refresh is skipped because structural
+        // equality confirms the content hasn't changed.
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================


### PR DESCRIPTION
💡 What: Converted `CartSummary` from a regular class to a `data class` in `demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt` and updated the corresponding assertions in `RecompositionRegressionTest.kt`.

🎯 Why: In Jetpack Compose, passing a regular class as a parameter to a composable causes recomposition whenever the parent recomposes, even if the fields hold the same values. This happens because regular classes use reference equality. By changing `CartSummary` to a `data class`, Compose uses structural equality and can correctly skip recomposing `CartBanner` when the cart content is identical.

📊 Impact: Reduces unnecessary recompositions of the `CartBanner` component. In scenarios where a parent recomposes independently of the cart (e.g., clicking the "Refresh" button), `CartBanner`'s recompositions drop from 1:1 with the parent to zero.

🔬 Measurement: Verified by running the UI test suite in `demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt`, where the assertions for `cart_banner` were updated to assert `assertStable()` on unrelated refresh actions and specifically exactly 2 recompositions instead of >= 3 when intermingled with unrelated updates.

---
*PR created automatically by Jules for task [6712786668367440288](https://jules.google.com/task/6712786668367440288) started by @himattm*