### PR TITLE
⚡ Bolt: [performance improvement] Optimize CartSummary to use structural equality

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Unstable class parameter causing unnecessary recomposition
+**Learning:** In Compose, regular classes passed as parameters to Composables are compared using reference equality by default (`Object.equals`). This means a new instance of the class will trigger recomposition even if the logical content is exactly the same, causing unnecessary recompositions of child components.
+**Action:** When creating state wrapper classes to pass to Composables, use `data class` instead of `class`. This ensures that `equals()` performs structural equality, so Compose can skip recomposition if the logical content hasn't changed.

--- a/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
+++ b/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.unit.dp
 // ISSUE: Unstable class — uses identity-based equality (Object.equals),
 // causing recomposition even when the logical content is the same.
 // Making this a `data class` would fix the problem.
-class CartSummary(val itemCount: Int, val totalPrice: String)
+data class CartSummary(val itemCount: Int, val totalPrice: String)
 
 @Composable
 fun ProductListScreen() {

--- a/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
+++ b/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
@@ -116,7 +116,7 @@ class RecompositionRegressionTest {
         composeTestRule.onNodeWithTag("refresh_button").performClick()
 
         // ISSUE: CartBanner recomposes despite no logical change to the cart
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 1)
+        composeTestRule.onNodeWithTag("cart_banner").assertStable()
 
         // FIX: If CartSummary were a `data class`, equals() would compare
         // fields structurally. CartSummary(0, "$0.0") == CartSummary(0, "$0.0")
@@ -163,7 +163,7 @@ class RecompositionRegressionTest {
         // recomposition because CartSummary is unstable. That's 5 total
         // recompositions (2 from selects + 3 from refreshes).
         // Budget: at most 5 -- bounded at 1:1 with parent recompositions.
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atMost = 5)
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
 
         // FIX: With `data class CartSummary`, only the 2 select clicks
         // would cause recomposition (the content actually changes).
@@ -201,7 +201,7 @@ class RecompositionRegressionTest {
         // because each parent recomposition creates a new CartSummary instance.
         // FIX: With `data class CartSummary`, only the 2 selects would cause
         // recomposition. The fixed assertion would be: assertRecomposesExactly(2)
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 3)
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================


### PR DESCRIPTION
💡 What: Changed `class CartSummary` to `data class CartSummary`.
🎯 Why: In Compose, regular classes passed as parameters to Composables are compared using reference equality by default (`Object.equals`). This means a new instance of the class will trigger recomposition even if the logical content is exactly the same, causing unnecessary recompositions of child components. Using a data class ensures that `equals()` performs structural equality, so Compose can skip recomposition if the logical content hasn't changed.
📊 Impact: Reduces `CartBanner` recompositions. Previously, `CartBanner` would recompose on every parent recomposition (e.g., when the refresh counter updated). Now it only recomposes when the cart's items or total actually change.
🔬 Measurement: Updated `RecompositionRegressionTest` assertions to verify that `CartBanner` now correctly avoids unnecessary recompositions (`assertStable()`, `assertRecompositions(exactly = 2)`).

---
*PR created automatically by Jules for task [1856540880611953287](https://jules.google.com/task/1856540880611953287) started by @himattm*