### PR TITLE
⚡ Bolt: [performance improvement] Optimize CartBanner recomposition using data classes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2023-10-27 - [Compose Performance] Structural Equality with Data Classes
+**Learning:** In Compose, passing regular classes (which use reference/identity equality) as state parameters can cause unnecessary recompositions. When a parent recomposes, it might create a new instance of the class even if the fields are identical. The child composable sees a new reference and recomposes unnecessarily.
+**Action:** Always use `data class` for state objects passed as parameters in Compose to ensure structural equality (`equals()` checks fields instead of references) and allow Compose to skip recomposition when the content hasn't changed.

--- a/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
+++ b/demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.unit.dp
 // ISSUE: Unstable class — uses identity-based equality (Object.equals),
 // causing recomposition even when the logical content is the same.
 // Making this a `data class` would fix the problem.
-class CartSummary(val itemCount: Int, val totalPrice: String)
+data class CartSummary(val itemCount: Int, val totalPrice: String)
 
 @Composable
 fun ProductListScreen() {

--- a/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
+++ b/demo/src/androidTest/java/demo/app/RecompositionRegressionTest.kt
@@ -116,12 +116,10 @@ class RecompositionRegressionTest {
         composeTestRule.onNodeWithTag("refresh_button").performClick()
 
         // ISSUE: CartBanner recomposes despite no logical change to the cart
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 1)
-
-        // FIX: If CartSummary were a `data class`, equals() would compare
+        // FIX: CartSummary is now a `data class`, equals() compares
         // fields structurally. CartSummary(0, "$0.0") == CartSummary(0, "$0.0")
-        // would be true, and Compose would SKIP the recomposition.
-        // The fixed assertion would be: assertFirstComposition()
+        // is true, and Compose SKIPs the recomposition.
+        composeTestRule.onNodeWithTag("cart_banner").assertStable()
     }
 
     // ============================================================
@@ -163,11 +161,9 @@ class RecompositionRegressionTest {
         // recomposition because CartSummary is unstable. That's 5 total
         // recompositions (2 from selects + 3 from refreshes).
         // Budget: at most 5 -- bounded at 1:1 with parent recompositions.
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atMost = 5)
-
         // FIX: With `data class CartSummary`, only the 2 select clicks
-        // would cause recomposition (the content actually changes).
-        // The fixed assertion would be: assertRecomposesExactly(2)
+        // cause recomposition (the content actually changes).
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================
@@ -199,9 +195,8 @@ class RecompositionRegressionTest {
 
         // ISSUE: CartBanner recomposes on ALL 3 interactions (2 selects + 1 refresh)
         // because each parent recomposition creates a new CartSummary instance.
-        // FIX: With `data class CartSummary`, only the 2 selects would cause
-        // recomposition. The fixed assertion would be: assertRecomposesExactly(2)
-        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(atLeast = 3)
+        // FIX: With `data class CartSummary`, only the 2 selects cause recomposition.
+        composeTestRule.onNodeWithTag("cart_banner").assertRecompositions(exactly = 2)
     }
 
     // ============================================================


### PR DESCRIPTION
💡 What:
Changed `class CartSummary` to `data class CartSummary` in `demo-shared/src/commonMain/kotlin/demo/app/ui/ProductList.kt` and updated the UI tests in `RecompositionRegressionTest.kt` to reflect the fixed behavior using Dejavu assertions (`assertStable()` and `assertRecompositions(exactly = 2)`).

🎯 Why:
In Compose, passing regular classes (which use identity/reference equality) as state parameters causes unnecessary recompositions. When a parent recomposes, it can create a new instance of the class even if all logical fields are identical. The child composable sees a new reference and recomposes needlessly. By using a `data class`, Compose leverages structural equality (`equals()` checks fields instead of object identity), allowing it to skip recomposition when the content hasn't changed.

📊 Impact:
Reduces `CartBanner` recompositions. Previously, `CartBanner` recomposed on every unrelated parent recomposition (like refresh clicks). Now it only recomposes when the actual content (item count or total price) changes. This significantly limits wasted recomposition cycles and reduces the performance budget.

🔬 Measurement:
Run the tests with `./gradlew test` and `./gradlew :demo-shared:jvmTest` to ensure that `RecompositionRegressionTest.kt` passes with the new assertions: `assertStable()` on unrelated interactions and bounded recomposition (`exactly = 2`) on mixed interactions.

---
*PR created automatically by Jules for task [2906847697508876739](https://jules.google.com/task/2906847697508876739) started by @himattm*