### PR TITLE
Bundle Claude Code skills + plugin for AI agents using Dejavu

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "dejavu",
+  "owner": {
+    "name": "Matt McKenna",
+    "url": "https://github.com/himattm"
+  },
+  "plugins": [
+    {
+      "name": "dejavu",
+      "source": "./",
+      "description": "AI agent skills for authoring Compose UI recomposition tests with Dejavu and running a closed-loop perf optimization workflow.",
+      "version": "0.1.0"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "dejavu",
+  "description": "AI agent skills for authoring Compose UI recomposition tests with the Dejavu library and running a closed-loop perf optimization workflow.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Matt McKenna",
+    "url": "https://github.com/himattm"
+  },
+  "homepage": "https://dejavu.mmckenna.me",
+  "repository": "https://github.com/himattm/dejavu",
+  "license": "Apache-2.0",
+  "keywords": [
+    "compose",
+    "android",
+    "kotlin-multiplatform",
+    "ui-testing",
+    "recomposition",
+    "skills"
+  ]
+}

--- a/.claude/skills/dejavu-error-triage/SKILL.md
+++ b/.claude/skills/dejavu-error-triage/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: dejavu-error-triage
+description: Triage a single Dejavu recomposition assertion failure. Use when the user pastes a UnexpectedRecompositionsError block, asks why a composable recomposed, mentions "Possible cause" / "Recomposition timeline" / "All tracked composables" output, or wants to understand what a Dejavu error means and apply one fix — without setting up an iterative optimization loop.
+---
+
+# Dejavu Error Triage
+
+You have ONE failing Dejavu assertion. This skill walks the error
+section-by-section, names the underlying recomposition pattern, and points at
+the canonical fix. Apply the fix, re-run the test, done — no iteration loop.
+
+If the goal is iterative optimization (loose `atMost = N` baseline → tighten
+to `assertStable()`), use the **`dejavu-perf-loop`** skill instead.
+If no Dejavu test exists yet, use **`dejavu-test-writer`** first.
+
+## Reference docs (read first)
+
+- `docs/error-messages.md` — full anatomy of the error block (sections 1–7,
+  lines 11–40 for the canonical example) and "Common Failure Patterns" 1–5
+  (lines 168–256).
+- `docs/causality-analysis.md` — what each "Possible cause" line means,
+  including same-value writes and dirty-bit signals.
+
+## Read the error in this order
+
+`docs/error-messages.md` "Reading the Error Quickly" (lines 260–269)
+prescribes this; follow it strictly:
+
+1. **Expected vs Actual** — quantify the gap (e.g. expected 0, actual 3).
+2. **All tracked composables** — find the `<-- FAILED` marker. If the parent's
+   count equals the failed child's count, you have a parent cascade.
+3. **Possible cause** — `same-value write` is an immediate bug;
+   `Parameter/parent change detected (dirty bits set)` means dirty bits fired.
+4. **Recomposition timeline** — `param slots changed: [N]` tells you which
+   parameter's dirty bit fired (slot 0 = first parameter).
+5. **Composable: name (File.kt:NN)** — jump to source.
+
+Don't guess. Read all five before naming a cause.
+
+## Diagnosis → fix table
+
+Apply the **first matching row**. After applying, re-run the test once.
+
+| # | Signal in the error | Diagnosis | Fix |
+|---|---|---|---|
+| 1 | `Possible cause:` includes `same-value write` | State written to a value equal to current; reference inequality still triggered recomposition | `data class` for the state holder, OR `mutableStateOf(value, policy = structuralEqualityPolicy())`, OR guard write site with `if (newValue != state.value) state.value = newValue` |
+| 2 | `Parameter/parent change detected (dirty bits set)` AND `param slots changed: [N]` AND the param at slot N is a non-data-class | Reference equality on an unstable type; new instance ≠ old instance even with identical fields | Convert param's class to `data class`, or annotate `@Immutable` / `@Stable` |
+| 3 | Multiple recompositions on a single interaction; param type broader than what the function actually uses (e.g. `Int` only used in `> 0`) | Type granularity is too coarse | Narrow the parameter type (`Int → Boolean`, `List → Boolean`/`size`) |
+| 4 | Same as #3 but the consumer reads a fine-grained value at every parent recomposition AND a derived signal flips less often | Fine-grained state should be coalesced before the boundary | `val coarse by remember { derivedStateOf { fineState.someProperty } }`; pass `coarse` |
+| 5 | Parent and many siblings have the same count in `All tracked composables` | Child cascades whenever parent recomposes for unrelated reasons | Hoist the state read into the leaf composable that needs it; or pass `State<T>` and read `.value` in the consumer |
+| 6 | Same composable repeats in the timeline once per list item, no `key()` block in the source | Compose can't track item identity across reorderings | `items(list, key = { it.id })`; or `key(it.id) { … }` |
+| 7 | Many siblings recompose together because parent re-runs for a coarse reason | Parent state is too broad; siblings inherit the cascade | Move the state into a `CompositionLocal`; or split parent into a stable shell + a state-reading inner composable |
+| 8 | `Recomposition timeline` shows `#1`, `#2`, `#3` at increasing timestamps with different `param slots changed` slots | Multiple independent state writes, each invalidating different slots | Batch with `Snapshot.withMutableSnapshot { … }`; consolidate related state into one object; or use `derivedStateOf` to coalesce |
+| ? | Pattern doesn't match | Don't guess | Re-read `docs/error-messages.md` "Common Failure Patterns" 1–5 (lines 168–256) and `docs/causality-analysis.md` summary table (lines 251–257) before suggesting a fix |
+
+## Special cases
+
+- **`Warning: testTag '...' could not be mapped to a composable function`** — the
+  tag is on a framework-internal node. Move `Modifier.testTag()` to the
+  outermost user-defined composable's modifier. (`docs/error-messages.md`
+  Pattern 3.)
+- **`Actual: composable was never composed or isn't being tracked`** — the tag
+  doesn't exist in the composition. For lazy lists, scroll the item into view
+  before asserting. (`docs/error-messages.md` Pattern 5.)
+- **`IllegalArgumentException` from the assertion itself** — invalid parameter
+  combination (e.g. `exactly = 1, atLeast = 1`). Fix the assertion call, not
+  the composable.
+
+## Wrap-up
+
+Report back to the user with:
+
+1. **The diagnosis** — quote the specific signal that matched (e.g. "row #2:
+   `Parameter/parent change detected` + `param slots changed: [0]` + `class
+   CartSummary` is not a `data class`").
+2. **The recommended fix** — one specific, applicable change with the file
+   and line.
+3. **Whether to apply it now** — only edit code if the user explicitly asked
+   for a fix, not just a diagnosis. If you're unsure, ask.
+4. **Whether iteration is needed** — if the count is much higher than expected
+   (e.g. expected `exactly = 0`, actual `7`) and one fix likely won't get all
+   the way to the floor, recommend invoking `dejavu-perf-loop` instead of
+   guessing the next fix.

--- a/.claude/skills/dejavu-error-triage/SKILL.md
+++ b/.claude/skills/dejavu-error-triage/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: dejavu-error-triage
-description: Triage a single Dejavu recomposition assertion failure. Use when the user pastes a UnexpectedRecompositionsError block, asks why a composable recomposed, mentions "Possible cause" / "Recomposition timeline" / "All tracked composables" output, or wants to understand what a Dejavu error means and apply one fix — without setting up an iterative optimization loop.
+description: Diagnose and fix a Dejavu test failure. Use when a Compose UI test failed with UnexpectedRecompositionsError, when CI or a local gradle/IDE test run shows a Dejavu assertion failure, when the user pastes the failure output (sections like "Possible cause", "Recomposition timeline", "All tracked composables"), or when the user asks why a Dejavu test is failing and how to fix it — without setting up an iterative optimization loop.
 ---
 
 # Dejavu Error Triage
 
-You have ONE failing Dejavu assertion. This skill walks the error
-section-by-section, names the underlying recomposition pattern, and points at
-the canonical fix. Apply the fix, re-run the test, done — no iteration loop.
+A Compose UI test failed with `UnexpectedRecompositionsError`. This skill walks
+the failure output section-by-section, names the underlying recomposition
+pattern, and points at the canonical fix. Apply the fix, re-run the failing
+test, done — no iteration loop.
 
 If the goal is iterative optimization (loose `atMost = N` baseline → tighten
 to `assertStable()`), use the **`dejavu-perf-loop`** skill instead.
@@ -20,6 +21,19 @@ If no Dejavu test exists yet, use **`dejavu-test-writer`** first.
   (lines 168–256).
 - `docs/causality-analysis.md` — what each "Possible cause" line means,
   including same-value writes and dirty-bit signals.
+
+## Locate the failure in the test output
+
+The error block is what the test runner (gradle, Robolectric, the IDE runner,
+CI logs) prints when a Dejavu assertion throws. Look for:
+
+- `dejavu.UnexpectedRecompositionsError:` — the exception class line.
+- The failing test method (e.g. `MyTest > assertionFailed FAILED`).
+- The full multi-line block that follows, ending with the semantic tree dump.
+
+Capture the **complete** block — every section is diagnostic input. Truncated
+output (just the exception message) hides the cause. If the user pasted only a
+header, ask for the full output.
 
 ## Read the error in this order
 
@@ -39,11 +53,11 @@ Don't guess. Read all five before naming a cause.
 
 ## Diagnosis → fix table
 
-Apply the **first matching row**. After applying, re-run the test once.
+Apply the **first matching row**. After applying, re-run the failing test once.
 
 | # | Signal in the error | Diagnosis | Fix |
 |---|---|---|---|
-| 1 | `Possible cause:` includes `same-value write` | State written to a value equal to current; reference inequality still triggered recomposition | `data class` for the state holder, OR `mutableStateOf(value, policy = structuralEqualityPolicy())`, OR guard write site with `if (newValue != state.value) state.value = newValue` |
+| 1 | `Possible cause:` includes `same-value write` | Snapshot fired an apply notification even though the new value equaled the old one, so the consumer recomposed unnecessarily | `data class` for the state holder, OR `mutableStateOf(value, policy = structuralEqualityPolicy())`, OR guard write site with `if (newValue != state.value) state.value = newValue` |
 | 2 | `Parameter/parent change detected (dirty bits set)` AND `param slots changed: [N]` AND the param at slot N is a non-data-class | Reference equality on an unstable type; new instance ≠ old instance even with identical fields | Convert param's class to `data class`, or annotate `@Immutable` / `@Stable` |
 | 3 | Multiple recompositions on a single interaction; param type broader than what the function actually uses (e.g. `Int` only used in `> 0`) | Type granularity is too coarse | Narrow the parameter type (`Int → Boolean`, `List → Boolean`/`size`) |
 | 4 | Same as #3 but the consumer reads a fine-grained value at every parent recomposition AND a derived signal flips less often | Fine-grained state should be coalesced before the boundary | `val coarse by remember { derivedStateOf { fineState.someProperty } }`; pass `coarse` |
@@ -77,7 +91,12 @@ Report back to the user with:
    and line.
 3. **Whether to apply it now** — only edit code if the user explicitly asked
    for a fix, not just a diagnosis. If you're unsure, ask.
-4. **Whether iteration is needed** — if the count is much higher than expected
+4. **How to verify** — re-run the specific failing test, not the full suite.
+   For gradle:
+   `./gradlew :<module>:<task> --tests "<ClassName>.<testName>"`. The fix
+   worked iff the assertion that previously threw now passes and no other
+   asserts regressed.
+5. **Whether iteration is needed** — if the count is much higher than expected
    (e.g. expected `exactly = 0`, actual `7`) and one fix likely won't get all
    the way to the floor, recommend invoking `dejavu-perf-loop` instead of
    guessing the next fix.

--- a/.claude/skills/dejavu-onboarding/SKILL.md
+++ b/.claude/skills/dejavu-onboarding/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: dejavu-onboarding
+description: Add the Dejavu library to a project from scratch. Use when the user wants to install or set up Dejavu, add the gradle dependency, write their first recomposition test in a project that doesn't have Dejavu yet, or get Dejavu working in an existing Android or Kotlin Multiplatform codebase.
+---
+
+# Dejavu Onboarding
+
+Add Dejavu to a project that doesn't have it yet. Covers the gradle
+dependency, the test rule setup, the first `Modifier.testTag` placement,
+and the smallest possible passing test that proves Dejavu is wired up.
+
+If Dejavu is already set up and the user wants to write more tests, hand off
+to **`dejavu-test-writer`**. If they're triaging a failing assertion, use
+**`dejavu-error-triage`**. If they want an iterative perf-optimization loop,
+use **`dejavu-perf-loop`**.
+
+## Reference docs (read first)
+
+- `docs/getting-started.md` — minimal Android setup (the canonical 2-step
+  install).
+- `README.md` — "KMP Test Setup" section (lines ~186–202) for non-Android
+  targets.
+- `README.md` — "Compatibility" section for Compose BOM / Kotlin version
+  requirements (`compose-runtime` 1.2.0+, Kotlin 2.0+).
+
+## Workflow
+
+### 1. Confirm prerequisites
+
+Verify the project meets Dejavu's compatibility floor before touching anything:
+
+- **Compose runtime ≥ 1.2.0** (the `CompositionTracer` API is required).
+- **Kotlin ≥ 2.0** with the Compose compiler plugin applied.
+- **JVM 17+** for Android and Desktop targets.
+
+If any of these are below floor, stop and tell the user — Dejavu can't be
+installed without them. Don't try to upgrade Compose/Kotlin as part of
+onboarding; that's a separate decision.
+
+### 2. Determine the project shape
+
+Ask (or infer from `build.gradle.kts`):
+
+- **Android-only app** → add Dejavu to the `androidTest` source set.
+- **KMP library or app with Compose Multiplatform** → add Dejavu to the
+  `commonTest` source set so Desktop / iOS / Wasm tests can use it.
+- **Both** → wire it into `androidTest` for instrumented coverage AND
+  `commonTest` for KMP coverage; the same Maven artifact serves both.
+
+### 3. Add the gradle dependency
+
+For Android (single-platform):
+
+```kotlin
+// app/build.gradle.kts
+dependencies {
+    androidTestImplementation("me.mmckenna.dejavu:dejavu:0.3.1")
+}
+```
+
+For Kotlin Multiplatform:
+
+```kotlin
+// shared/build.gradle.kts
+kotlin {
+    sourceSets {
+        commonTest.dependencies {
+            implementation("me.mmckenna.dejavu:dejavu:0.3.1")
+        }
+    }
+}
+```
+
+Use the latest version from Maven Central (the README badge has the current
+number). Don't downgrade if the project is already on a newer release.
+
+### 4. Pick a target composable for the first test
+
+Choose ONE composable that:
+
+- Already exists in the project (don't write code under test as part of
+  onboarding).
+- Has a clear "should never recompose" intuition (a static title, an icon, a
+  label that depends on no state).
+
+This becomes the first `assertStable()` target — the simplest assertion to
+prove Dejavu works.
+
+### 5. Add `Modifier.testTag()` to the target
+
+Tags must be on the outermost user-defined composable's modifier. If the
+target doesn't have one yet:
+
+```kotlin
+@Composable
+fun StaticTitle() {
+    Text("My App", modifier = Modifier.testTag("static_title"))
+}
+```
+
+Use snake_case for tag names by convention.
+
+### 6. Write the smallest possible test
+
+For Android (instrumented test source set, e.g.
+`app/src/androidTest/java/.../MyFirstDejavuTest.kt`):
+
+```kotlin
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import dejavu.assertStable
+import dejavu.createRecompositionTrackingRule
+import org.junit.Rule
+import org.junit.Test
+
+class MyFirstDejavuTest {
+
+    @get:Rule
+    val composeTestRule = createRecompositionTrackingRule<MainActivity>()
+
+    @Test
+    fun staticTitle_isStable_afterAnyClick() {
+        composeTestRule.onNodeWithTag("any_button").performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag("static_title").assertStable()
+    }
+}
+```
+
+For KMP (`commonTest`):
+
+```kotlin
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import dejavu.assertStable
+import dejavu.runRecompositionTrackingUiTest
+import dejavu.setTrackedContent
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class MyFirstDejavuTest {
+    @Test
+    fun staticTitle_isStable() = runRecompositionTrackingUiTest {
+        setTrackedContent { MyScreen() }
+        waitForIdle()
+        onNodeWithTag("static_title").assertStable()
+    }
+}
+```
+
+### 7. Run the test
+
+| Project shape | Command |
+|---|---|
+| Android instrumented | `./gradlew :app:connectedDebugAndroidTest` |
+| KMP Desktop JVM | `./gradlew :shared:jvmTest` |
+| KMP iOS simulator | `./gradlew :shared:iosSimulatorArm64Test` |
+| KMP Wasm browser | `./gradlew :shared:wasmJsBrowserTest` |
+
+Substitute the actual module name. If the test passes, Dejavu is wired up
+correctly.
+
+### 8. Optional: enable runtime logcat streaming (Android only)
+
+Useful if the user wants AI agents to follow recomposition events in real
+time outside of tests. Add to a debug `Application`:
+
+```kotlin
+Dejavu.enable(app = this, logToLogcat = true)
+```
+
+Filter logcat with tag `Dejavu`. See `docs/use-cases.md` "Stream Composition State to AI Agents via Logcat" for the format.
+
+## Common gotchas
+
+- **Test fails with "node has no testTag"** — the tag wasn't applied; check
+  the modifier is on the outermost composable.
+- **Test fails with `Actual: composable was never composed`** — the target
+  isn't on screen during the test; for lazy items, scroll into view first.
+- **Compose compiler plugin missing** — `createRecompositionTrackingRule`
+  works without it, but tag-to-function mapping degrades. Add the Compose
+  compiler plugin if it isn't already configured.
+- **`LazyVerticalGrid` on iOS/Wasm** — upstream Compose runtime crash; pick
+  a different composable for the first test if the screen has one
+  (`README.md` Known Gaps).
+
+## Wrap-up
+
+Once the first test passes:
+
+1. Tell the user Dejavu is wired up and the smallest assertion runs.
+2. Hand off to **`dejavu-test-writer`** for the next test (real assertions
+   on real interactions).
+3. Point at `docs/getting-started.md` and `docs/examples.md` for further
+   patterns the project may want to adopt.
+4. Don't add more tests automatically — the onboarding job is done.

--- a/.claude/skills/dejavu-onboarding/SKILL.md
+++ b/.claude/skills/dejavu-onboarding/SKILL.md
@@ -58,14 +58,29 @@ dependencies {
 }
 ```
 
-For Kotlin Multiplatform:
+For Kotlin Multiplatform — pick the form that matches the project's existing
+gradle DSL:
 
 ```kotlin
-// shared/build.gradle.kts
+// shared/build.gradle.kts (Kotlin 2.0+ accessor DSL)
 kotlin {
     sourceSets {
         commonTest.dependencies {
             implementation("me.mmckenna.dejavu:dejavu:0.3.1")
+        }
+    }
+}
+```
+
+Older builds (or projects that haven't migrated their gradle scripts) use:
+
+```kotlin
+kotlin {
+    sourceSets {
+        val commonTest by getting {
+            dependencies {
+                implementation("me.mmckenna.dejavu:dejavu:0.3.1")
+            }
         }
     }
 }
@@ -142,7 +157,7 @@ import kotlin.test.Test
 class MyFirstDejavuTest {
     @Test
     fun staticTitle_isStable() = runRecompositionTrackingUiTest {
-        setTrackedContent { MyScreen() }
+        setTrackedContent { StaticTitle() }   // the composable from step 5
         waitForIdle()
         onNodeWithTag("static_title").assertStable()
     }

--- a/.claude/skills/dejavu-perf-loop/SKILL.md
+++ b/.claude/skills/dejavu-perf-loop/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: dejavu-perf-loop
+description: Optimize a Compose composable's recomposition behavior using Dejavu as a closed-loop validator. Use when the user asks to reduce recompositions, find why a composable recomposes, lock in a recomposition optimization, hit a recomposition budget, fix a header/banner cascade, investigate "Possible cause" / "Recomposition timeline" output, or apply derivedStateOf / @Immutable / data class fixes driven by failing Dejavu assertions.
+---
+
+# Dejavu Perf Loop
+
+Iteratively optimize the recomposition behavior of a Compose composable using
+Dejavu as the validator. The loop is: write/extend a test → run → read the
+failure → apply ONE fix → re-run → tighten the assertion → repeat until the
+target hits its theoretical recomposition minimum. The final test is the
+regression guard.
+
+## Reference docs (read before fixing)
+
+- `docs/error-messages.md` — full error structure and "Common Failure Patterns"
+  (#1–5). Read sections 1–7, lines 11–40 for the canonical example.
+- `docs/causality-analysis.md` — what "Possible cause" actually means; summary
+  table at the bottom (lines 251–257).
+- `docs/examples.md` — Examples 2 (Boolean narrowing, lines 89–124), 3 (data
+  class, lines 132–171), 8 (`derivedStateOf`, lines 462–493).
+
+## Companion skill
+
+This skill assumes a Dejavu test exists or can be written. To author or extend
+the test, **invoke the `dejavu-test-writer` skill** — read its `SKILL.md` at
+`.claude/skills/dejavu-test-writer/SKILL.md` and follow its workflow, then
+return here with a working test that has a baseline assertion.
+
+## Workflow
+
+### 1. Pick a target
+
+Identify ONE composable + ONE user interaction. Examples:
+- "ProductHeader after refresh button click"
+- "CartBanner after item selection"
+- "DerivedBanner after select-all"
+
+Narrow scope makes diagnosis tractable. Don't try to optimize a whole screen
+at once.
+
+### 2. Establish a baseline test
+
+Either extend an existing test or write a new one (use `dejavu-test-writer`).
+Start with a LOOSE upper bound and at least one stable sibling:
+
+```kotlin
+@Test
+fun productHeader_recompositionBudget() {
+    composeTestRule.onNodeWithTag("refresh_button").performClick()
+    composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithTag("product_header").assertRecompositions(atMost = 10)
+    composeTestRule.onNodeWithTag("static_label").assertStable()   // scoping guard
+}
+```
+
+The baseline's job is not to pass — it's to capture a real number you can shrink.
+
+### 3. Run the test, observe the count
+
+Run the appropriate gradle command (see `dejavu-test-writer` "Run the test").
+- If `atMost = 10` passes, lower it progressively (`5`, `3`, `2`, `1`) and re-run
+  until it FAILS. The first failing `N - 1` is the current actual count.
+- When it fails, capture the **full** error block. Every section in
+  `docs/error-messages.md` is a diagnostic input.
+
+### 4. Compute the theoretical minimum
+
+For the interaction you triggered:
+- 0 state changes that the target reads → `assertStable()` should hold
+- 1 state change the target reads → `1` is the floor
+- N independent state changes the target reads → `N` is the floor (unless coalesced)
+
+If actual > theoretical, proceed to Step 5. Otherwise tighten and commit.
+
+### 5. Apply the decision tree below — ONE fix at a time
+
+Read the Dejavu error and match against the table. Apply exactly one fix per
+iteration. Multiple fixes at once make it impossible to attribute the count
+change.
+
+### 6. Tighten the assertion after each successful fix
+
+- Actual dropped to 0 → replace `atMost` with `assertStable()`
+- Actual dropped to known N → replace `atMost` with `assertRecompositions(exactly = N)`
+- Still bounded but lower → lower `atMost`, leave a TODO to tighten further
+
+**Never raise `atMost` to make a test pass.** That's a regression, not an
+optimization.
+
+### 7. Repeat until convergence
+
+Convergence = actual equals theoretical minimum AND assertion is `exactly` /
+`assertStable()`.
+
+### 8. Commit the locked-in test as a regression guard
+
+Add a one-line comment naming the cookbook entry the test guards. Don't commit
+unless the user asks.
+
+## Decision tree: error pattern → fix
+
+Apply the **first matching row**. Re-run the test after every fix.
+
+| # | Error signal in Dejavu output | Fix to apply | Reference |
+|---|---|---|---|
+| 1 | `Possible cause:` includes `same-value write` | Convert state holder to `data class` for structural equality; OR `mutableStateOf(value, policy = structuralEqualityPolicy())`; OR guard at write site: `if (newValue != state.value) state.value = newValue` | `error-messages.md` Pattern 2; `causality-analysis.md` |
+| 2 | `Possible cause:` says `Parameter/parent change detected (dirty bits set)` AND timeline shows `param slots changed: [N]` AND the param's type is a non-data-class | Convert the param's class to `data class`, or annotate `@Immutable` / `@Stable` | `examples.md` Example 3 (lines 132–171) |
+| 3 | Multiple recompositions on a single interaction; param type is broader than what the function actually uses (e.g. `Int` only used in `> 0`, list only used for `.isNotEmpty()`) | Narrow the parameter type (e.g. `Int → Boolean`, `List → Boolean` or `List → size`) | `examples.md` Example 2 (lines 89–124) |
+| 4 | Same as #3 but the consumer reads a fine-grained value at every parent recomposition AND the derived signal flips less often | `val coarse by remember { derivedStateOf { fineState.someProperty } }`; pass `coarse` to the child | `examples.md` Example 8 (lines 462–493) |
+| 5 | `All tracked composables` shows the parent and many siblings with the same count; child cascades whenever parent recomposes for unrelated reasons | Hoist the state read into the leaf composable that needs it; OR pass `State<T>` and read `.value` in the consumer | `error-messages.md` Pattern 1 |
+| 6 | Same composable appears in the timeline once per list item with no `key()` block | Add `key = { it.id }` to `items()`; or wrap loop bodies in `key(it.id) { … }` | — |
+| 7 | Many siblings recompose together because parent re-runs for a coarse reason | Push the changing state into its own `CompositionLocal` so only readers re-run; OR split the parent into a stable shell + a state-reading inner composable | `examples.md` Example 7 |
+| 8 | Timeline shows `#1`, `#2`, `#3` at increasing timestamps with different `param slots changed` slots, suggesting independent state writes | Batch with `Snapshot.withMutableSnapshot { … }`; OR consolidate related state into one object; OR use `derivedStateOf` to coalesce | `error-messages.md` Pattern 4 |
+| ? | Unknown / ambiguous error | Re-read `error-messages.md` "Reading the Error Quickly" (lines 260–269) — read in order: Expected vs Actual → cascade marker → Possible cause → timeline → source location. Don't guess. | `error-messages.md` |
+
+## How to read the error fast
+
+1. **Expected vs Actual** — the gap.
+2. **All tracked composables** — find the `<-- FAILED` marker. If the parent has
+   the same count as the failed child, you have a cascade (rows #5 / #7).
+3. **Possible cause** — `same-value write` (row #1) is an immediate bug;
+   `Parameter/parent change` is the start of the dirty-bit investigation.
+4. **Recomposition timeline** — `param slots changed: [N]` tells you which
+   parameter's dirty bit fired. Map slot index to function-signature position
+   (slot 0 = first param).
+5. **Composable source location** — `Composable: pkg.Name (File.kt:NN)` jumps
+   you to the function.
+
+## Wrap-up
+
+The final, locked-in test should:
+
+- Use `assertStable()` or `assertRecompositions(exactly = N)` — never `atMost`.
+- Have at least one sibling `assertStable()` to prove scoping.
+- Carry a one-line comment naming the cookbook entry it guards
+  (e.g. `// Locks in row #3 (Boolean narrowing) for ProductHeader`).
+
+When reporting back to the user, surface:
+
+- Before / after recomposition counts.
+- The specific cookbook row applied (and the fix's `examples.md` line range).
+- The exact gradle command that proves the regression guard works.

--- a/.claude/skills/dejavu-perf-loop/SKILL.md
+++ b/.claude/skills/dejavu-perf-loop/SKILL.md
@@ -20,13 +20,16 @@ regression guard.
 - `docs/examples.md` — Examples 2 (Boolean narrowing, lines 89–124), 3 (data
   class, lines 132–171), 8 (`derivedStateOf`, lines 462–493).
 
-## Companion skill
+## Companion skills
 
-This skill assumes a Dejavu test exists or can be written. To author or extend
-the test, **invoke the `dejavu-test-writer` skill** and follow its workflow,
-then return here with a working test that has a baseline assertion. Both
-skills ship together — in-repo at `.claude/skills/dejavu-test-writer/SKILL.md`,
-and as the `dejavu` plugin when installed elsewhere.
+- **`dejavu-test-writer`** — author or extend the baseline test if one
+  doesn't exist yet. Invoke it first, return here with a working test that
+  has a loose `atMost = N` assertion.
+- **`dejavu-error-triage`** — for one-shot "explain this single failure"
+  questions where the user just wants the diagnosis and one fix, not an
+  iterative loop.
+- **`dejavu-onboarding`** — only if the project doesn't have Dejavu wired up
+  at all. Run that first.
 
 ## Workflow
 

--- a/.claude/skills/dejavu-perf-loop/SKILL.md
+++ b/.claude/skills/dejavu-perf-loop/SKILL.md
@@ -61,7 +61,10 @@ The baseline's job is not to pass — it's to capture a real number you can shri
 
 Run the appropriate gradle command (see `dejavu-test-writer` "Run the test").
 - If `atMost = 10` passes, lower it progressively (`5`, `3`, `2`, `1`) and re-run
-  until it FAILS. The first failing `N - 1` is the current actual count.
+  until it FAILS. If `atMost = N` is the first to fail and `atMost = M` (M > N)
+  was the previous pass, the actual count is in `[N + 1, M]`. To pin the exact
+  number, narrow the bracket with further probes (or, on Android, read it
+  directly via `composeTestRule.getRecompositionCount(tag)`).
 - When it fails, capture the **full** error block. Every section in
   `docs/error-messages.md` is a diagnostic input.
 

--- a/.claude/skills/dejavu-perf-loop/SKILL.md
+++ b/.claude/skills/dejavu-perf-loop/SKILL.md
@@ -23,9 +23,10 @@ regression guard.
 ## Companion skill
 
 This skill assumes a Dejavu test exists or can be written. To author or extend
-the test, **invoke the `dejavu-test-writer` skill** — read its `SKILL.md` at
-`.claude/skills/dejavu-test-writer/SKILL.md` and follow its workflow, then
-return here with a working test that has a baseline assertion.
+the test, **invoke the `dejavu-test-writer` skill** and follow its workflow,
+then return here with a working test that has a baseline assertion. Both
+skills ship together — in-repo at `.claude/skills/dejavu-test-writer/SKILL.md`,
+and as the `dejavu` plugin when installed elsewhere.
 
 ## Workflow
 

--- a/.claude/skills/dejavu-perf-loop/SKILL.md
+++ b/.claude/skills/dejavu-perf-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dejavu-perf-loop
-description: Optimize a Compose composable's recomposition behavior using Dejavu as a closed-loop validator. Use when the user asks to reduce recompositions, find why a composable recomposes, lock in a recomposition optimization, hit a recomposition budget, fix a header/banner cascade, investigate "Possible cause" / "Recomposition timeline" output, or apply derivedStateOf / @Immutable / data class fixes driven by failing Dejavu assertions.
+description: Optimize a Compose composable's recomposition behavior using Dejavu as a closed-loop validator. Use when the user asks to reduce recompositions, set or tighten a recomposition budget, lock in a recomposition optimization across multiple iterations, fix a recomposition cascade, or apply derivedStateOf / @Immutable / data class fixes iteratively across multiple test runs until the count hits its theoretical floor.
 ---
 
 # Dejavu Perf Loop

--- a/.claude/skills/dejavu-perf-loop/SKILL.md
+++ b/.claude/skills/dejavu-perf-loop/SKILL.md
@@ -5,11 +5,17 @@ description: Optimize a Compose composable's recomposition behavior using Dejavu
 
 # Dejavu Perf Loop
 
-Iteratively optimize the recomposition behavior of a Compose composable using
-Dejavu as the validator. The loop is: write/extend a test → run → read the
-failure → apply ONE fix → re-run → tighten the assertion → repeat until the
-target hits its theoretical recomposition minimum. The final test is the
-regression guard.
+Iteratively shape the recomposition behavior of a Compose composable until it
+matches what's *actually correct* for that composable, then lock the count
+in. The loop is: write/extend a test → run → read the failure → apply ONE
+fix → re-run → tighten the assertion → repeat until the count matches the
+theoretical floor. The final test is the regression guard.
+
+**The floor may not be zero.** A composable that legitimately reads N
+independent state sources will recompose N times — that's correct, not a bug.
+The goal is to make the assertion match reality (`assertRecompositions(exactly = N)`),
+not to drive every count to `assertStable()`. Use the cookbook only when the
+actual count exceeds the theoretical floor.
 
 ## Reference docs (read before fixing)
 
@@ -72,16 +78,32 @@ Run the appropriate gradle command (see `dejavu-test-writer` "Run the test").
 - When it fails, capture the **full** error block. Every section in
   `docs/error-messages.md` is a diagnostic input.
 
-### 4. Compute the theoretical minimum
+### 4. Compute the theoretical floor (which may not be zero)
 
-For the interaction you triggered:
-- 0 state changes that the target reads → `assertStable()` should hold
-- 1 state change the target reads → `1` is the floor
-- N independent state changes the target reads → `N` is the floor (unless coalesced)
+For the interaction you triggered, count what the target composable
+*legitimately* reads:
 
-If actual > theoretical, proceed to Step 5. Otherwise tighten and commit.
+- 0 state sources read by the target → floor is 0; `assertStable()` should hold
+- 1 state source read by the target → floor is 1
+- N independent state sources read by the target → floor is N (unless coalesced
+  by `derivedStateOf` or batched by `Snapshot.withMutableSnapshot`)
+
+If actual == floor, **you're done with the optimization phase** — skip step 5
+and go to step 6 to tighten the assertion to `exactly = floor` (or
+`assertStable()` if the floor is 0).
+
+If actual > floor, proceed to step 5 to find the waste.
+
+If actual < floor, something is suspicious — the test isn't exercising what
+you think it is, or `Modifier.testTag` is on the wrong node. Re-check the
+test before celebrating.
 
 ### 5. Apply the decision tree below — ONE fix at a time
+
+This step only applies when **actual > floor**. The cookbook is for finding
+unnecessary recompositions; if the count is already correct for what the
+composable does, don't try to "optimize" it further — that's how you end up
+with brittle tests or subtle bugs.
 
 Read the Dejavu error and match against the table. Apply exactly one fix per
 iteration. Multiple fixes at once make it impossible to attribute the count
@@ -89,21 +111,26 @@ change.
 
 ### 6. Tighten the assertion after each successful fix
 
-- Actual dropped to 0 → replace `atMost` with `assertStable()`
-- Actual dropped to known N → replace `atMost` with `assertRecompositions(exactly = N)`
-- Still bounded but lower → lower `atMost`, leave a TODO to tighten further
+Always end with an **exact** assertion — never `atMost`:
+
+- Floor is N (any non-zero value) → `assertRecompositions(exactly = N)`
+- Floor is 0 → `assertStable()` (alias for `exactly = 0`, clearer intent)
+- Still bounded but lower than the previous run → lower `atMost` and leave a
+  TODO; keep iterating
 
 **Never raise `atMost` to make a test pass.** That's a regression, not an
 optimization.
 
 ### 7. Repeat until convergence
 
-Convergence = actual equals theoretical minimum AND assertion is `exactly` /
-`assertStable()`.
+Convergence = actual equals the floor AND the assertion is `exactly = N` (or
+`assertStable()` when the floor is 0). Loose `atMost` bounds are not
+convergent; they're a "still in progress" marker.
 
 ### 8. Commit the locked-in test as a regression guard
 
-Add a one-line comment naming the cookbook entry the test guards. Don't commit
+Add a one-line comment naming the cookbook entry the test guards (or noting
+that the count was already at floor and just needed locking in). Don't commit
 unless the user asks.
 
 ## Decision tree: error pattern → fix
@@ -139,13 +166,19 @@ Apply the **first matching row**. Re-run the test after every fix.
 
 The final, locked-in test should:
 
-- Use `assertStable()` or `assertRecompositions(exactly = N)` — never `atMost`.
-- Have at least one sibling `assertStable()` to prove scoping.
+- Use `assertRecompositions(exactly = N)` when the floor is non-zero, or
+  `assertStable()` when the floor is 0. **Never `atMost`.** The exact count
+  reflects the composable's actual contract.
+- Have at least one sibling `assertStable()` (or `exactly = N` for siblings
+  that should also have a known floor) to prove scoping.
 - Carry a one-line comment naming the cookbook entry it guards
-  (e.g. `// Locks in row #3 (Boolean narrowing) for ProductHeader`).
+  (e.g. `// Locks in row #3 (Boolean narrowing): ProductHeader recomposes once per visibility flip`),
+  or noting "already at floor; locked in" if no fix was needed.
 
 When reporting back to the user, surface:
 
-- Before / after recomposition counts.
-- The specific cookbook row applied (and the fix's `examples.md` line range).
+- Before / after recomposition counts (and the floor — so it's clear when the
+  count was already correct vs. reduced).
+- The specific cookbook row applied, if any (and the fix's `examples.md` line
+  range).
 - The exact gradle command that proves the regression guard works.

--- a/.claude/skills/dejavu-test-writer/SKILL.md
+++ b/.claude/skills/dejavu-test-writer/SKILL.md
@@ -9,10 +9,14 @@ Dejavu turns Compose recomposition behavior into JUnit/kotlin.test assertions. T
 skill picks the right setup, points at canonical examples, and gives you the API
 surface in one screen so you can write a correct test on the first try.
 
-This skill teaches you how to **write a test**. It is a companion to
-`dejavu-perf-loop`, which uses these tests as a closed-loop validator to optimize
-recomposition behavior. If a count exceeds your assertion, do **not** loosen the
-assertion — invoke `dejavu-perf-loop` instead.
+This skill assumes Dejavu is already installed in the project. If it isn't,
+use **`dejavu-onboarding`** first to add the gradle dependency and prove the
+setup with a smallest-possible test, then come back here.
+
+This skill teaches you how to **write a test**. Companion skills:
+- **`dejavu-error-triage`** — diagnose a single failing assertion.
+- **`dejavu-perf-loop`** — iteratively reduce a composable's recomposition
+  count. If a count exceeds your assertion, do **not** loosen it — escalate.
 
 ## Reference docs (read first)
 

--- a/.claude/skills/dejavu-test-writer/SKILL.md
+++ b/.claude/skills/dejavu-test-writer/SKILL.md
@@ -189,8 +189,7 @@ After writing or editing a test:
 
 1. Run the matching gradle command above and fix failures.
 2. **If the count exceeds your assertion, do NOT loosen it** — invoke the
-   `dejavu-perf-loop` skill (at `.claude/skills/dejavu-perf-loop/SKILL.md`) to
-   diagnose and fix the underlying recomposition cause, then come back with a
-   tightened assertion.
+   `dejavu-perf-loop` skill to diagnose and fix the underlying recomposition
+   cause, then come back with a tightened assertion.
 3. Leave at least one `assertStable()` on a sibling composable that should not
    be affected — it locks in the scoping guarantee and catches setup mistakes.

--- a/.claude/skills/dejavu-test-writer/SKILL.md
+++ b/.claude/skills/dejavu-test-writer/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: dejavu-test-writer
+description: Author Compose UI recomposition tests using the Dejavu library. Use when adding a new test for a Compose composable, retrofitting recomposition assertions onto an existing UI test, deciding between Android instrumented vs KMP common tests, or when the user mentions Dejavu, recomposition counts, assertRecompositions, assertStable, or createRecompositionTrackingRule.
+---
+
+# Dejavu Test Writer
+
+Dejavu turns Compose recomposition behavior into JUnit/kotlin.test assertions. This
+skill picks the right setup, points at canonical examples, and gives you the API
+surface in one screen so you can write a correct test on the first try.
+
+This skill teaches you how to **write a test**. It is a companion to
+`dejavu-perf-loop`, which uses these tests as a closed-loop validator to optimize
+recomposition behavior. If a count exceeds your assertion, do **not** loosen the
+assertion — invoke `dejavu-perf-loop` instead.
+
+## Reference docs (read first)
+
+Read these before generating any test code:
+
+- `docs/getting-started.md` — minimal Android setup
+- `docs/examples.md` — eight canonical patterns, including LazyColumn,
+  AnimatedVisibility, deep nesting, CompositionLocal, and `derivedStateOf`
+- `docs/error-messages.md` — failure output anatomy (used by the perf-loop skill)
+- `README.md` — KMP setup section + Known Limitations / Known Gaps
+
+## Canonical examples to copy from
+
+| Style | File |
+|---|---|
+| Android JUnit4 | `demo/src/androidTest/java/demo/app/AssertionApiTest.kt` |
+| KMP common test | `dejavu/src/commonTest/kotlin/dejavu/AssertionApiPatternTest.kt` |
+| Smallest KMP example | `dejavu/src/commonTest/kotlin/dejavu/DejavuComposeUiTest.kt` |
+| Tagged composable | `demo-shared/src/commonMain/kotlin/demo/app/ui/Counter.kt` |
+| Optimization patterns (more) | `dejavu/src/commonTest/kotlin/dejavu/*PatternTest.kt` |
+
+## API at a glance
+
+### Android (JUnit4) setup
+
+```kotlin
+import dejavu.assertRecompositions
+import dejavu.assertStable
+import dejavu.createRecompositionTrackingRule
+
+@get:Rule
+val composeTestRule = createRecompositionTrackingRule<MyActivity>()
+// or createRecompositionTrackingRule() for plain ComponentActivity host
+```
+
+`createRecompositionTrackingRule` wraps `createAndroidComposeRule`, enables Dejavu
+before each test, resets counts, and disables on teardown. Drop-in replacement.
+
+### KMP (commonTest / Desktop / iOS / Wasm) setup
+
+```kotlin
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import dejavu.assertStable
+import dejavu.runRecompositionTrackingUiTest
+import dejavu.setTrackedContent
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class MyTest {
+    @Test
+    fun myComposable_isStable() = runRecompositionTrackingUiTest {
+        setTrackedContent { MyComposable() }
+        waitForIdle()
+        onNodeWithTag("my_tag").assertStable()
+    }
+}
+```
+
+`runRecompositionTrackingUiTest` is the KMP equivalent of the Android rule. It
+handles tracer setup, inspection-table seeding, state reset, and teardown.
+`setTrackedContent` is the tracked equivalent of `setContent` — required for tag
+mapping on non-Android platforms.
+
+### Assertions
+
+```kotlin
+onNodeWithTag(tag).assertRecompositions(exactly = N)
+onNodeWithTag(tag).assertRecompositions(atLeast = N)
+onNodeWithTag(tag).assertRecompositions(atMost = N)
+onNodeWithTag(tag).assertRecompositions(atLeast = N, atMost = M)
+onNodeWithTag(tag).assertStable()                         // alias for exactly = 0
+```
+
+Validation rules (`SemanticNodeInteractions.kt:33-50`): exactly one of `exactly` or
+`atLeast`/`atMost`; `exactly` cannot combine with the range params; all bounds must
+be `>= 0`; `atLeast <= atMost`. Violations throw `IllegalArgumentException`.
+
+### Mid-test reset (Android)
+
+```kotlin
+composeTestRule.resetRecompositionCounts()
+```
+
+Clears recomposition counts but preserves composition history. Use between setup
+and the actual interaction under test (`docs/examples.md` Tips section).
+
+### Programmatic read (Android only)
+
+```kotlin
+val n: Int = composeTestRule.getRecompositionCount("my_tag")
+```
+
+## Workflow
+
+### 1. Decide where the test lives
+
+- **Android-only feature, needs an Activity / hardware** →
+  `demo/src/androidTest/...` (or your project's instrumented test source set)
+- **Cross-platform composable** → `dejavu/src/commonTest/...` (or your KMP
+  module's `commonTest`)
+- See `CLAUDE.md` "Project Structure" for module roles.
+
+### 2. Tag every assertion target
+
+Add `Modifier.testTag("my_tag")` to the composable you want to assert on. The tag
+must be on a user-defined composable's modifier — framework-internal nodes cannot
+be mapped (`docs/error-messages.md` Pattern 3). Convention: snake_case strings.
+
+### 3. Pick the assertion mode
+
+- `assertStable()` — "this should never recompose" (clearest intent)
+- `assertRecompositions(exactly = N)` — known count, regression guard
+- `assertRecompositions(atMost = N)` — recomposition budget; tighten this over
+  time using the perf-loop skill
+- `assertRecompositions(atLeast = N)` — sanity check that an interaction did
+  trigger recomposition
+
+### 4. Drive UI → waitForIdle → assert
+
+```kotlin
+composeTestRule.onNodeWithTag("inc_button").performClick()
+composeTestRule.waitForIdle()                              // ALWAYS
+composeTestRule.onNodeWithTag("counter_value").assertRecompositions(exactly = 1)
+```
+
+Skip `waitForIdle()` and counts become racy. Same applies to `performTextInput`
+and any other interaction.
+
+### 5. Reset between phases of multi-step tests
+
+When the test has setup actions plus a measured interaction, reset between them
+so the assertion only counts the interaction under test:
+
+```kotlin
+composeTestRule.onNodeWithTag("select_0_btn").performClick()
+composeTestRule.waitForIdle()
+composeTestRule.resetRecompositionCounts()                 // forget setup
+
+composeTestRule.onNodeWithTag("select_all_btn").performClick()
+composeTestRule.waitForIdle()
+composeTestRule.onNodeWithTag("derived_banner").assertStable()
+```
+
+### 6. Run the test
+
+This repo's convention (`CLAUDE.md` "Gradle"):
+
+```bash
+./gradlew -q --console=plain :dejavu:jvmTest                    # Desktop JVM (KMP common)
+./gradlew -q --console=plain :dejavu:testDebugUnitTest           # Android unit tests
+./gradlew -q --console=plain :dejavu:iosSimulatorArm64Test       # iOS sim (KMP common)
+./gradlew -q --console=plain :dejavu:wasmJsBrowserTest           # Wasm headless browser
+./gradlew -q --console=plain :demo:connectedDebugAndroidTest     # Android instrumented
+./gradlew -q --console=plain apiCheck                            # API compat
+```
+
+Always pass `-q --console=plain`.
+
+## Common gotchas
+
+- **Off-screen lazy items** — scroll into view before asserting; off-screen items have no composition (`README.md` Known Limitations).
+- **`exactly` + range mutual exclusion** — `exactly` cannot combine with `atLeast`/`atMost`; throws `IllegalArgumentException`.
+- **Negative bounds** — all bounds must be `>= 0`.
+- **`assertStable()` vs `exactly = 0`** — identical; prefer `assertStable()` for intent.
+- **`LazyVerticalGrid` on iOS/Wasm** — upstream Compose crash; use `LazyColumn`/`LazyRow` (`README.md` Known Gaps).
+- **Wasm assertion-message swallowing** — don't introspect `AssertionError.message` on Wasm; pass/fail still works.
+- **`testTag` placement** — put the tag on the outermost user-defined composable's modifier, not buried inside framework primitives.
+- **Activity-owned clock** — `createAndroidComposeRule` uses the real Recomposer; use plain `createComposeRule()` for clock control.
+
+## Wrap-up
+
+After writing or editing a test:
+
+1. Run the matching gradle command above and fix failures.
+2. **If the count exceeds your assertion, do NOT loosen it** — invoke the
+   `dejavu-perf-loop` skill (at `.claude/skills/dejavu-perf-loop/SKILL.md`) to
+   diagnose and fix the underlying recomposition cause, then come back with a
+   tightened assertion.
+3. Leave at least one `assertStable()` on a sibling composable that should not
+   be affected — it locks in the scoping guarantee and catches setup mistakes.

--- a/.claude/skills/dejavu-test-writer/SKILL.md
+++ b/.claude/skills/dejavu-test-writer/SKILL.md
@@ -163,18 +163,19 @@ composeTestRule.onNodeWithTag("derived_banner").assertStable()
 
 ### 6. Run the test
 
-This repo's convention (`CLAUDE.md` "Gradle"):
+Substitute `<module>` with the gradle module that holds the test (`:app:`,
+`:shared:`, `:feature-foo:`, etc.). In the Dejavu repo itself, that's
+`:dejavu:` for KMP common tests and `:demo:` for Android instrumented tests
+(`CLAUDE.md` "Gradle"; pass `-q --console=plain` by convention there).
 
 ```bash
-./gradlew -q --console=plain :dejavu:jvmTest                    # Desktop JVM (KMP common)
-./gradlew -q --console=plain :dejavu:testDebugUnitTest           # Android unit tests
-./gradlew -q --console=plain :dejavu:iosSimulatorArm64Test       # iOS sim (KMP common)
-./gradlew -q --console=plain :dejavu:wasmJsBrowserTest           # Wasm headless browser
-./gradlew -q --console=plain :demo:connectedDebugAndroidTest     # Android instrumented
-./gradlew -q --console=plain apiCheck                            # API compat
+./gradlew :<module>:jvmTest                   # Desktop JVM (KMP common)
+./gradlew :<module>:testDebugUnitTest          # Android unit tests (Robolectric)
+./gradlew :<module>:iosSimulatorArm64Test      # iOS sim (KMP common)
+./gradlew :<module>:wasmJsBrowserTest          # Wasm headless browser
+./gradlew :<module>:connectedDebugAndroidTest  # Android instrumented
+./gradlew apiCheck                             # API compat
 ```
-
-Always pass `-q --console=plain`.
 
 ## Common gotchas
 

--- a/.claude/skills/dejavu-test-writer/SKILL.md
+++ b/.claude/skills/dejavu-test-writer/SKILL.md
@@ -115,8 +115,10 @@ val n: Int = composeTestRule.getRecompositionCount("my_tag")
 Before writing anything new, search the project's test source sets for tests
 that already exercise the target composable:
 
-- `grep -rE "onNodeWithTag\(.<your-tag>.\)" src/*Test*` (or use the project's
-  test directory layout).
+- Grep recursively in the test source sets for `onNodeWithTag(`, e.g.
+  `grep -rEn 'onNodeWithTag\(' src/test src/androidTest src/commonTest 2>/dev/null`.
+  Substitute the project's actual test directory layout. Narrow with the
+  specific tag name (`'onNodeWithTag\("my_tag"\)'`) once you have one.
 - Look for a sibling test file (`MyScreen.kt` → `MyScreenTest.kt` /
   `MyScreenInstrumentedTest.kt`).
 - Skim for tests that drive the same interaction you want to assert on
@@ -126,7 +128,7 @@ that already exercise the target composable:
 
 > I found existing Compose UI tests that cover `<Composable>` in
 > `<TestFile>.kt`. Do you want to:
-> 1. **Augment** them — swap to `createRecompositionTrackingRule` and add
+> 1. **Augment** them — swap the rule for the Dejavu equivalent and add
 >    `assertStable()` / `assertRecompositions(...)` calls inside the existing
 >    test methods. Co-locates behavior + recomposition checks. No new files.
 > 2. **Add new tests** — keep the existing tests untouched and create a
@@ -143,12 +145,15 @@ below.
 Three changes; the rest of the workflow's tagging / assertion / `waitForIdle`
 / reset / run steps still apply.
 
-1. **Swap the rule.** Drop-in replacement, no test logic changes.
-   - Android: `createAndroidComposeRule()` → `createRecompositionTrackingRule()`
-     (both forms accept a generic activity type, e.g.
-     `createRecompositionTrackingRule<MainActivity>()`).
-   - KMP: `runComposeUiTest { … }` → `runRecompositionTrackingUiTest { … }`
-     and inside, `setContent { … }` → `setTrackedContent { … }`.
+1. **Swap the rule.** Branch on which factory the existing test uses — the
+   wrong swap won't compile or will silently change the test host.
+
+   | Existing rule | Swap to | Notes |
+   |---|---|---|
+   | `createAndroidComposeRule()` / `createAndroidComposeRule<A>()` | `createRecompositionTrackingRule()` / `createRecompositionTrackingRule<A>()` | Drop-in. Same Activity type. |
+   | `createComposeRule()` (no Activity — used for `mainClock.advanceTimeBy()` or pure-Compose modules) | **No public drop-in.** Either (a) migrate the test body to `runRecompositionTrackingUiTest { setTrackedContent { … } }` (loses the Activity; gains tracer setup), or (b) keep the rule and add `Dejavu.enable(app)` in `@Before` and `Dejavu.disable()` in `@After` manually. | Don't blindly swap to `createRecompositionTrackingRule()` — it requires an Activity. |
+   | `runComposeUiTest { … }` (KMP `commonTest`) | `runRecompositionTrackingUiTest { … }`, plus inside, `setContent { … }` → `setTrackedContent { … }` | Drop-in. |
+
 2. **Add `Modifier.testTag(...)`** to any composable you want to assert on
    that doesn't already have one. Outermost user modifier; snake_case tags.
 3. **Add Dejavu assertions** alongside the existing ones (don't replace
@@ -162,6 +167,12 @@ intuition for the interaction under test, plus at least one stable-sibling
 guard (see the wrap-up).
 
 ## Workflow
+
+The numbered steps below cover writing a NEW test. If the user picked
+augmentation above, the existing test's location and module are already
+settled — skip step 1, skip step 2 for any composable that already has a
+`testTag`, and start at step 3 (assertion mode) for the new assertions.
+Steps 4 (`waitForIdle`), 5 (mid-test reset), and 6 (run) apply to both paths.
 
 ### 1. Decide where the test lives
 
@@ -203,13 +214,15 @@ When the test has setup actions plus a measured interaction, reset between them
 so the assertion only counts the interaction under test:
 
 ```kotlin
-composeTestRule.onNodeWithTag("select_0_btn").performClick()
+// Setup phase: get the UI into the right state, then forget the counts.
+composeTestRule.onNodeWithTag("setup_action").performClick()
 composeTestRule.waitForIdle()
-composeTestRule.resetRecompositionCounts()                 // forget setup
+composeTestRule.resetRecompositionCounts()
 
-composeTestRule.onNodeWithTag("select_all_btn").performClick()
+// Measurement phase: only this interaction's recompositions are counted.
+composeTestRule.onNodeWithTag("measured_action").performClick()
 composeTestRule.waitForIdle()
-composeTestRule.onNodeWithTag("derived_banner").assertStable()
+composeTestRule.onNodeWithTag("target").assertStable()
 ```
 
 ### 6. Run the test

--- a/.claude/skills/dejavu-test-writer/SKILL.md
+++ b/.claude/skills/dejavu-test-writer/SKILL.md
@@ -110,6 +110,57 @@ and the actual interaction under test (`docs/examples.md` Tips section).
 val n: Int = composeTestRule.getRecompositionCount("my_tag")
 ```
 
+## First: are there existing Compose UI tests for this composable?
+
+Before writing anything new, search the project's test source sets for tests
+that already exercise the target composable:
+
+- `grep -rE "onNodeWithTag\(.<your-tag>.\)" src/*Test*` (or use the project's
+  test directory layout).
+- Look for a sibling test file (`MyScreen.kt` → `MyScreenTest.kt` /
+  `MyScreenInstrumentedTest.kt`).
+- Skim for tests that drive the same interaction you want to assert on
+  (`performClick`, `performTextInput`, etc.).
+
+**If matches exist, ask the user which path to take BEFORE changing code:**
+
+> I found existing Compose UI tests that cover `<Composable>` in
+> `<TestFile>.kt`. Do you want to:
+> 1. **Augment** them — swap to `createRecompositionTrackingRule` and add
+>    `assertStable()` / `assertRecompositions(...)` calls inside the existing
+>    test methods. Co-locates behavior + recomposition checks. No new files.
+> 2. **Add new tests** — keep the existing tests untouched and create a
+>    parallel `<Composable>RecompositionTest.kt`. Cleaner separation; some
+>    setup duplication.
+>
+> Which would you prefer?
+
+If no matches exist, default to a new test and continue with the workflow
+below.
+
+### Augmenting an existing test (if the user picks path 1)
+
+Three changes; the rest of the workflow's tagging / assertion / `waitForIdle`
+/ reset / run steps still apply.
+
+1. **Swap the rule.** Drop-in replacement, no test logic changes.
+   - Android: `createAndroidComposeRule()` → `createRecompositionTrackingRule()`
+     (both forms accept a generic activity type, e.g.
+     `createRecompositionTrackingRule<MainActivity>()`).
+   - KMP: `runComposeUiTest { … }` → `runRecompositionTrackingUiTest { … }`
+     and inside, `setContent { … }` → `setTrackedContent { … }`.
+2. **Add `Modifier.testTag(...)`** to any composable you want to assert on
+   that doesn't already have one. Outermost user modifier; snake_case tags.
+3. **Add Dejavu assertions** alongside the existing ones (don't replace
+   them). For multi-phase tests, call
+   `composeTestRule.resetRecompositionCounts()` between the setup actions
+   and the measured interaction.
+
+Don't add `assertStable()` / `assertRecompositions(...)` to every node — pick
+the ones that have a clear "should be stable" or "should recompose exactly N"
+intuition for the interaction under test, plus at least one stable-sibling
+guard (see the wrap-up).
+
 ## Workflow
 
 ### 1. Decide where the test lives

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@
 .externalNativeBuild
 .cxx
 local.properties
-.claude/
+.claude/*
+!.claude/skills/
 .kotlin/
 site/
 docs/api/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Bundled Claude Code skills `dejavu-test-writer` and `dejavu-perf-loop` in `.claude/skills/` to help AI agents author Dejavu tests and run an iterative recomposition-optimization loop using Dejavu as the validator.
+- Packaged the same skills as a Claude Code plugin (`dejavu`) installable via `/plugin marketplace add himattm/dejavu` + `/plugin install dejavu@dejavu`. Plugin manifest at `.claude-plugin/plugin.json`, marketplace at `.claude-plugin/marketplace.json`, with `skills/` symlinked into `.claude/skills/` for a single source of truth.
 
 ## [0.3.1] - 2026-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Bundled Claude Code skills `dejavu-test-writer` and `dejavu-perf-loop` in `.claude/skills/` to help AI agents author Dejavu tests and run an iterative recomposition-optimization loop using Dejavu as the validator.
+- Bundled four Claude Code skills in `.claude/skills/` to help AI agents adopt Dejavu, author tests, triage failures, and run an iterative recomposition-optimization loop:
+  - `dejavu-onboarding` — adds Dejavu to a project from scratch (gradle dependency, first `Modifier.testTag`, smallest passing test).
+  - `dejavu-test-writer` — authors Compose UI recomposition tests using Dejavu's APIs.
+  - `dejavu-error-triage` — one-shot diagnosis of a single `UnexpectedRecompositionsError` block.
+  - `dejavu-perf-loop` — closed-loop optimization using Dejavu as the validator.
 - Packaged the same skills as a Claude Code plugin (`dejavu`) installable via `/plugin marketplace add himattm/dejavu` + `/plugin install dejavu@dejavu`. Plugin manifest at `.claude-plugin/plugin.json`, marketplace at `.claude-plugin/marketplace.json`, with `skills/` symlinked into `.claude/skills/` for a single source of truth.
 
 ## [0.3.1] - 2026-04-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Bundled Claude Code skills `dejavu-test-writer` and `dejavu-perf-loop` in `.claude/skills/` to help AI agents author Dejavu tests and run an iterative recomposition-optimization loop using Dejavu as the validator.
+
 ## [0.3.1] - 2026-04-15
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,12 +47,16 @@ Always run with `-q --console=plain`.
 
 ## Bundled Claude skills
 
-This repo ships two skills under `.claude/skills/` for AI agents working with Dejavu:
+This repo ships four skills under `.claude/skills/` for AI agents working with Dejavu:
 
+- `dejavu-onboarding` — add Dejavu to a project from scratch (gradle dependency, first test).
 - `dejavu-test-writer` — author Compose UI recomposition tests using Dejavu's APIs.
+- `dejavu-error-triage` — one-shot diagnosis of a single failing `UnexpectedRecompositionsError`.
 - `dejavu-perf-loop` — closed-loop optimization of a composable's recomposition behavior, using Dejavu as the validator. Invokes `dejavu-test-writer` to establish the baseline test.
 
-Both skills point at the canonical docs in `docs/` and the canonical test patterns in `dejavu/src/commonTest/kotlin/dejavu/*PatternTest.kt` rather than duplicating them. They auto-load for sessions opened in this repo.
+The four skills cross-reference each other so the agent can flow between them: onboarding → test-writer → (error-triage | perf-loop) depending on whether the user wants a one-shot fix or an iteration loop.
+
+All skills point at the canonical docs in `docs/` and the canonical test patterns in `dejavu/src/commonTest/kotlin/dejavu/*PatternTest.kt` rather than duplicating them. They auto-load for sessions opened in this repo.
 
 ### Plugin layout
 
@@ -60,6 +64,6 @@ The same skills are also packaged as a Claude Code plugin so users outside this 
 
 - `.claude-plugin/plugin.json` — plugin manifest (`name: dejavu`).
 - `.claude-plugin/marketplace.json` — single-plugin marketplace listing.
-- `skills/dejavu-test-writer/`, `skills/dejavu-perf-loop/` — symlinks into `.claude/skills/` so the canonical SKILL.md files have one source of truth. Edit the canonical files under `.claude/skills/`; the plugin layout picks up the change via symlink.
+- `skills/<skill-name>/` — symlinks into `.claude/skills/` so the canonical SKILL.md files have one source of truth. Edit the canonical files under `.claude/skills/`; the plugin layout picks up the change via symlink.
 
 Install instructions for end-users live in `README.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,3 +44,12 @@ Minimum verification after any code change:
 ## Gradle
 
 Always run with `-q --console=plain`.
+
+## Bundled Claude skills
+
+This repo ships two skills under `.claude/skills/` for AI agents working with Dejavu:
+
+- `dejavu-test-writer` — author Compose UI recomposition tests using Dejavu's APIs.
+- `dejavu-perf-loop` — closed-loop optimization of a composable's recomposition behavior, using Dejavu as the validator. Invokes `dejavu-test-writer` to establish the baseline test.
+
+Both skills point at the canonical docs in `docs/` and the canonical test patterns in `dejavu/src/commonTest/kotlin/dejavu/*PatternTest.kt` rather than duplicating them. They auto-load for sessions opened in this repo; downstream consumers can copy them into their own `.claude/skills/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,4 +52,14 @@ This repo ships two skills under `.claude/skills/` for AI agents working with De
 - `dejavu-test-writer` — author Compose UI recomposition tests using Dejavu's APIs.
 - `dejavu-perf-loop` — closed-loop optimization of a composable's recomposition behavior, using Dejavu as the validator. Invokes `dejavu-test-writer` to establish the baseline test.
 
-Both skills point at the canonical docs in `docs/` and the canonical test patterns in `dejavu/src/commonTest/kotlin/dejavu/*PatternTest.kt` rather than duplicating them. They auto-load for sessions opened in this repo; downstream consumers can copy them into their own `.claude/skills/`.
+Both skills point at the canonical docs in `docs/` and the canonical test patterns in `dejavu/src/commonTest/kotlin/dejavu/*PatternTest.kt` rather than duplicating them. They auto-load for sessions opened in this repo.
+
+### Plugin layout
+
+The same skills are also packaged as a Claude Code plugin so users outside this repo can install them globally:
+
+- `.claude-plugin/plugin.json` — plugin manifest (`name: dejavu`).
+- `.claude-plugin/marketplace.json` — single-plugin marketplace listing.
+- `skills/dejavu-test-writer/`, `skills/dejavu-perf-loop/` — symlinks into `.claude/skills/` so the canonical SKILL.md files have one source of truth. Edit the canonical files under `.claude/skills/`; the plugin layout picks up the change via symlink.
+
+Install instructions for end-users live in `README.md`.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,14 @@ When you optimize a composable — extracting a lambda, adding `remember`, switc
 
 AI coding agents can refactor composables and restructure state, but they have no way to know whether their changes made recomposition better or worse. Dejavu gives them that signal. When an agent runs your tests and a Dejavu assertion fails, the structured error message tells it exactly which composable regressed, by how much, and why — turning recomposition count into an optimization metric the agent can target directly.
 
-This repo ships two Claude Code skills under [`.claude/skills/`](.claude/skills/) — `dejavu-test-writer` (author or extend Dejavu UI tests) and `dejavu-perf-loop` (iteratively optimize a composable's recomposition behavior using Dejavu as the validator). Sessions opened in this repo auto-load them; downstream consumers can copy the directory into their own project to use the same skills.
+This repo ships two Claude Code skills — `dejavu-test-writer` (author or extend Dejavu UI tests) and `dejavu-perf-loop` (iteratively optimize a composable's recomposition behavior using Dejavu as the validator). Install them globally in Claude Code:
+
+```
+/plugin marketplace add himattm/dejavu
+/plugin install dejavu@dejavu
+```
+
+Sessions opened inside the Dejavu repo also auto-load the same skills from [`.claude/skills/`](.claude/skills/) without installing the plugin.
 
 ### Guardrail Against Unexpected Changes
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ When you optimize a composable — extracting a lambda, adding `remember`, switc
 
 AI coding agents can refactor composables and restructure state, but they have no way to know whether their changes made recomposition better or worse. Dejavu gives them that signal. When an agent runs your tests and a Dejavu assertion fails, the structured error message tells it exactly which composable regressed, by how much, and why — turning recomposition count into an optimization metric the agent can target directly.
 
+This repo ships two Claude Code skills under [`.claude/skills/`](.claude/skills/) — `dejavu-test-writer` (author or extend Dejavu UI tests) and `dejavu-perf-loop` (iteratively optimize a composable's recomposition behavior using Dejavu as the validator). Sessions opened in this repo auto-load them; downstream consumers can copy the directory into their own project to use the same skills.
+
 ### Guardrail Against Unexpected Changes
 
 When AI agents or automated tooling modify your codebase, they can introduce subtle changes to recomposition behavior without touching any visible UI. Dejavu tests act as guardrails — if an agent's changes cause a composable to recompose more than expected, the test fails before the change is merged. You get the speed of automated refactoring with the confidence that recomposition behavior is preserved.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,22 @@ dejavu.UnexpectedRecompositionsError: Recomposition assertion failed for testTag
 
 See [Error Messages Guide](https://dejavu.mmckenna.me/error-messages/) for how to read and act on each section.
 
+## Claude Code Skills (for AI Agents)
+
+Dejavu ships two Claude Code skills that teach AI agents how to use it:
+
+- **`dejavu-test-writer`** — author Compose UI recomposition tests using Dejavu's APIs (Android JUnit4 or KMP `commonTest`).
+- **`dejavu-perf-loop`** — closed-loop optimization of a composable's recomposition behavior, using Dejavu as the validator. Embeds an error-pattern → fix decision tree (data class, Boolean narrowing, `derivedStateOf`, hoisted reads, `key()`, `CompositionLocal`).
+
+Install them globally in Claude Code so they're available in any project:
+
+```
+/plugin marketplace add himattm/dejavu
+/plugin install dejavu@dejavu
+```
+
+Sessions opened inside this repo also auto-load the same skills from [`.claude/skills/`](.claude/skills/) without installing the plugin.
+
 ## Use Cases
 
 ### Lock In Efficiency Gains
@@ -102,14 +118,7 @@ When you optimize a composable — extracting a lambda, adding `remember`, switc
 
 AI coding agents can refactor composables and restructure state, but they have no way to know whether their changes made recomposition better or worse. Dejavu gives them that signal. When an agent runs your tests and a Dejavu assertion fails, the structured error message tells it exactly which composable regressed, by how much, and why — turning recomposition count into an optimization metric the agent can target directly.
 
-This repo ships two Claude Code skills — `dejavu-test-writer` (author or extend Dejavu UI tests) and `dejavu-perf-loop` (iteratively optimize a composable's recomposition behavior using Dejavu as the validator). Install them globally in Claude Code:
-
-```
-/plugin marketplace add himattm/dejavu
-/plugin install dejavu@dejavu
-```
-
-Sessions opened inside the Dejavu repo also auto-load the same skills from [`.claude/skills/`](.claude/skills/) without installing the plugin.
+For Claude Code users, the bundled `dejavu-test-writer` and `dejavu-perf-loop` skills (see [Claude Code Skills](#claude-code-skills-for-ai-agents) above) teach the agent how to author Dejavu tests and run an iterative perf-optimization loop without re-deriving the API from docs.
 
 ### Guardrail Against Unexpected Changes
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,11 @@ See [Error Messages Guide](https://dejavu.mmckenna.me/error-messages/) for how t
 
 ## Claude Code Skills (for AI Agents)
 
-Dejavu ships two Claude Code skills that teach AI agents how to use it:
+Dejavu ships four Claude Code skills that teach AI agents how to use it:
 
+- **`dejavu-onboarding`** — add Dejavu to a project from scratch (gradle dependency, first `Modifier.testTag`, smallest possible passing test).
 - **`dejavu-test-writer`** — author Compose UI recomposition tests using Dejavu's APIs (Android JUnit4 or KMP `commonTest`).
+- **`dejavu-error-triage`** — diagnose a single failing `UnexpectedRecompositionsError`: walks the error sections, names the pattern, points at the canonical fix.
 - **`dejavu-perf-loop`** — closed-loop optimization of a composable's recomposition behavior, using Dejavu as the validator. Embeds an error-pattern → fix decision tree (data class, Boolean narrowing, `derivedStateOf`, hoisted reads, `key()`, `CompositionLocal`).
 
 Install them globally in Claude Code so they're available in any project:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -57,7 +57,7 @@ See the [Error Messages Guide](error-messages.md) for how to read and act on eac
 
 ## Optional: Install the Claude Code skills
 
-If you use Claude Code, you can install the bundled `dejavu-test-writer` and `dejavu-perf-loop` skills globally so they're available in any project. The first authors Dejavu tests for you; the second iteratively optimizes a composable's recomposition behavior using Dejavu as the validator.
+If you use Claude Code, you can install the bundled Dejavu skills globally so they're available in any project. The skill set covers the full lifecycle: `dejavu-onboarding` (initial install), `dejavu-test-writer` (author tests), `dejavu-error-triage` (diagnose a single failure), and `dejavu-perf-loop` (iteratively optimize a composable's recomposition behavior using Dejavu as the validator).
 
 ```
 /plugin marketplace add himattm/dejavu

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,3 +54,14 @@ dejavu.UnexpectedRecompositionsError: Recomposition assertion failed for testTag
 ```
 
 See the [Error Messages Guide](error-messages.md) for how to read and act on each section.
+
+## Optional: Install the Claude Code skills
+
+If you use Claude Code, you can install the bundled `dejavu-test-writer` and `dejavu-perf-loop` skills globally so they're available in any project. The first authors Dejavu tests for you; the second iteratively optimizes a composable's recomposition behavior using Dejavu as the validator.
+
+```
+/plugin marketplace add himattm/dejavu
+/plugin install dejavu@dejavu
+```
+
+Sessions opened inside the [Dejavu repo](https://github.com/himattm/dejavu) auto-load the same skills from `.claude/skills/` without installing the plugin. See [Use Cases → Give AI Agents a Recomposition Signal](use-cases.md#give-ai-agents-a-recomposition-signal) for what the skills do in practice.

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,3 +35,14 @@ Dejavu is a test-only library that turns recomposition behavior into assertions.
 - [Examples](examples.md) — test patterns for common scenarios
 - [API Reference](api-reference.md) — all assertions and utilities
 - [How It Works](how-it-works.md) — internals, compatibility, and limitations
+
+## Using Claude Code?
+
+Install the bundled `dejavu-test-writer` and `dejavu-perf-loop` skills globally:
+
+```
+/plugin marketplace add himattm/dejavu
+/plugin install dejavu@dejavu
+```
+
+See [Use Cases → Give AI Agents a Recomposition Signal](use-cases.md#give-ai-agents-a-recomposition-signal) for what each skill does.

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ Dejavu is a test-only library that turns recomposition behavior into assertions.
 
 ## Using Claude Code?
 
-Install the bundled `dejavu-test-writer` and `dejavu-perf-loop` skills globally:
+Install the bundled Dejavu skills globally — they cover initial install (`dejavu-onboarding`), authoring tests (`dejavu-test-writer`), diagnosing single failures (`dejavu-error-triage`), and the iterative perf-optimization loop (`dejavu-perf-loop`):
 
 ```
 /plugin marketplace add himattm/dejavu

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -41,6 +41,24 @@ dejavu.UnexpectedRecompositionsError: Recomposition assertion failed for testTag
 
 The agent gets a clear, structured signal: which composable regressed, by how much, and why. It can use this to iterate — adjusting its approach until the assertion passes. This turns recomposition count into an optimization metric that an AI agent can target directly, rather than relying on vague heuristics about Compose best practices.
 
+### Claude Code skills
+
+For Claude Code users, Dejavu ships two skills as a Claude Code plugin so the agent knows how to write Dejavu tests and run an iterative perf-optimization loop without re-deriving the API from docs:
+
+- **`dejavu-test-writer`** — author Compose UI recomposition tests using Dejavu's APIs (Android JUnit4 or KMP `commonTest`).
+- **`dejavu-perf-loop`** — closed-loop optimization of a composable's recomposition behavior, using Dejavu as the validator. Embeds an error-pattern → fix decision tree (data class, Boolean narrowing, `derivedStateOf`, hoisted reads, `key()`, `CompositionLocal`).
+
+Install:
+
+```
+/plugin marketplace add himattm/dejavu
+/plugin install dejavu@dejavu
+```
+
+Sessions opened inside the [Dejavu repo](https://github.com/himattm/dejavu) auto-load the same skills from `.claude/skills/` without installing the plugin.
+
+### Programmatic checks
+
 You can also use `getRecompositionCount()` to let agents make programmatic decisions:
 
 ```kotlin

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -43,9 +43,11 @@ The agent gets a clear, structured signal: which composable regressed, by how mu
 
 ### Claude Code skills
 
-For Claude Code users, Dejavu ships two skills as a Claude Code plugin so the agent knows how to write Dejavu tests and run an iterative perf-optimization loop without re-deriving the API from docs:
+For Claude Code users, Dejavu ships four skills as a Claude Code plugin so the agent knows how to adopt Dejavu, write tests, triage failures, and run an iterative perf-optimization loop without re-deriving the API from docs:
 
+- **`dejavu-onboarding`** — add Dejavu to a project from scratch (gradle dependency, first `Modifier.testTag`, smallest possible passing test).
 - **`dejavu-test-writer`** — author Compose UI recomposition tests using Dejavu's APIs (Android JUnit4 or KMP `commonTest`).
+- **`dejavu-error-triage`** — diagnose a single failing `UnexpectedRecompositionsError`: walks the error sections, names the pattern, points at the canonical fix.
 - **`dejavu-perf-loop`** — closed-loop optimization of a composable's recomposition behavior, using Dejavu as the validator. Embeds an error-pattern → fix decision tree (data class, Boolean narrowing, `derivedStateOf`, hoisted reads, `key()`, `CompositionLocal`).
 
 Install:

--- a/skills/dejavu-error-triage
+++ b/skills/dejavu-error-triage
@@ -1,0 +1,1 @@
+../.claude/skills/dejavu-error-triage

--- a/skills/dejavu-onboarding
+++ b/skills/dejavu-onboarding
@@ -1,0 +1,1 @@
+../.claude/skills/dejavu-onboarding

--- a/skills/dejavu-perf-loop
+++ b/skills/dejavu-perf-loop
@@ -1,0 +1,1 @@
+../.claude/skills/dejavu-perf-loop

--- a/skills/dejavu-test-writer
+++ b/skills/dejavu-test-writer
@@ -1,0 +1,1 @@
+../.claude/skills/dejavu-test-writer


### PR DESCRIPTION
## Summary

Bundle four Claude Code skills with Dejavu and ship them as an installable Claude Code plugin so any user can run two commands and get an agent that knows how to adopt the library, write recomposition tests, triage failures, and run a closed-loop perf-optimization workflow.

## Skills

| Skill | Lines | Purpose |
|---|---|---|
| `dejavu-onboarding` | 197 | Add Dejavu to a project from scratch — prereq check, gradle dependency (Android or KMP), first `Modifier.testTag` placement, smallest passing test, gradle run command. |
| `dejavu-test-writer` | 199 | Author a Compose UI recomposition test in an already-installed project. Covers Android (`createRecompositionTrackingRule`) and KMP (`runRecompositionTrackingUiTest` + `setTrackedContent`), the assertion API surface, gotchas, and pointers at canonical examples. |
| `dejavu-error-triage` | 83 | One-shot diagnosis of a single `UnexpectedRecompositionsError`. Reads the error in the order prescribed by `docs/error-messages.md`, matches against an 8-row signal → fix table, recommends one fix. Escalates to `dejavu-perf-loop` when iteration is needed. |
| `dejavu-perf-loop` | 151 | Closed-loop optimization: write/extend a test → run → read failure → apply ONE fix → re-run → tighten → repeat until the composable hits its theoretical recomposition floor. |

The four skills cross-reference each other so the agent flows naturally: `onboarding → test-writer → (error-triage | perf-loop)`. They delegate to the existing `docs/*.md` and `*PatternTest.kt` files as canonical sources rather than duplicating content, so they stay in sync with the library.

## Plugin packaging

Same skills, installable globally via Claude Code:

```
/plugin marketplace add himattm/dejavu
/plugin install dejavu@dejavu
```

- `.claude-plugin/plugin.json` — plugin manifest (name `dejavu`, version `0.1.0`).
- `.claude-plugin/marketplace.json` — single-plugin marketplace so the repo itself is installable.
- `skills/<skill-name>/` — Git symlinks (mode 120000) into `.claude/skills/<skill-name>/`. Single source of truth: editors touch `.claude/skills/...`, the plugin layout picks up the change automatically.

## Supporting changes

- **`.gitignore`** — switched from a blanket `.claude/` exclusion to `.claude/*` + `!.claude/skills/`. Personal settings stay out of git; project-shipped skills travel with the repo.
- **`README.md`** — new top-level "Claude Code Skills (for AI Agents)" section right after "What a Failure Looks Like" listing all four skills with the install commands. The existing AI use-case bullet now cross-references it.
- **`CLAUDE.md`** — "Bundled Claude skills" + "Plugin layout" sections documenting all four skills and the symlink arrangement for future contributors.
- **`CHANGELOG.md`** — `[Unreleased] / Added` entries for the skills and the plugin.
- **Docs site** — install instructions added in three discoverable spots: `docs/index.md` (landing-page callout), `docs/getting-started.md` (optional install step), `docs/use-cases.md` (under "Give AI Agents a Recomposition Signal").

## Review feedback addressed

- **gemini-code-assist (line 64, recomp-count math):** Accepted. Replaced the incorrect "first failing N − 1" wording with the correct bracket `[N + 1, M]` (where M was the previous passing probe), plus a pointer to `getRecompositionCount(tag)` for an exact readout on Android. Commit `3e607db`.
- **gemini-code-assist (line 115, `withMutableSnapshot.apply()`):** Rejected with a [reply](https://github.com/himattm/dejavu/pull/71#discussion_r3148209754). `Snapshot.withMutableSnapshot { … }` already calls `apply().check()` internally and returns the result of `block`; chaining `.apply()` would invoke Kotlin's `Any.apply` scope function on the block's return value, not commit a snapshot.

## Test plan

Skills are pure markdown plus a JSON manifest — no Kotlin source touched, so the existing test suite is unaffected. Verification is best done via live skill activation in a fresh session:

- [ ] **Static checks:** `find .claude/skills -name SKILL.md` returns four paths; each frontmatter has a `name:` matching its directory and a `description:` containing "Use when…"; each `SKILL.md` is between 80 and 200 lines.
- [ ] **Plugin manifest:** `cat .claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` parse as valid JSON; `/plugin marketplace add himattm/dejavu` then `/plugin install dejavu@dejavu` works in a fresh project, exposing `/dejavu:dejavu-test-writer` etc.
- [ ] **`dejavu-onboarding`** — *"Add Dejavu to my project."* in a project without it: agent loads the skill, runs the prereq check, adds `androidTestImplementation("me.mmckenna.dejavu:dejavu:0.3.1")`, picks a target composable, writes the smallest possible `assertStable()` test, runs the matching gradle command.
- [ ] **`dejavu-test-writer`** — *"Write a Dejavu test that asserts CounterTitle is stable when I click inc_button."* → expect Android JUnit4 test using `createRecompositionTrackingRule()`, `Modifier.testTag("counter_title")`, `performClick`, `waitForIdle()`, `assertStable()`.
- [ ] **`dejavu-error-triage`** — paste a `UnexpectedRecompositionsError` block with `Possible cause: same-value write` → expect agent to load the skill, read sections in the prescribed order, match row #1 (data class / `structuralEqualityPolicy` / guarded write), recommend one fix.
- [ ] **`dejavu-perf-loop`** — *"ProductHeader recomposes 5 times when I click refresh — fix it and lock it in with a Dejavu test."* → expect Skill 4 to invoke Skill 2 for the baseline, recognize Boolean-narrowing pattern, apply FIX 2, tighten to `assertRecompositions(exactly = 1)`.

https://claude.ai/code/session_01YYDtzSLGAwb2BdjaRCu9fd